### PR TITLE
Remove context processor config as it is removed from allauth

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,12 +71,6 @@ in-depth steps on their configuration.)
         'django_otp.middleware.OTPMiddleware',
     )
 
-    TEMPLATE_CONTEXT_PROCESSORS = (
-        # Configure allauth.
-        'django.core.context_processors.request',
-        "allauth.account.context_processors.account",
-    )
-
     # Set the allauth adapter to be the 2FA adapter.
     ACCOUNT_ADAPTER = 'allauth_2fa.adapter.OTPAdapter'
 


### PR DESCRIPTION
See this: https://github.com/pennersr/django-allauth/blob/master/ChangeLog.rst#backwards-incompatible-changes-6
