### PR TITLE
Make otp_device not required

### DIFF
--- a/allauth_2fa/forms.py
+++ b/allauth_2fa/forms.py
@@ -12,6 +12,7 @@ class TOTPAuthenticateForm(OTPAuthenticationFormMixin, forms.Form):
     otp_token = forms.CharField(
         label=_("Token"),
     )
+    otp_device = forms.ChoiceField(required=False, choices=[])
 
     def __init__(self, user, **kwargs):
         super(TOTPAuthenticateForm, self).__init__(**kwargs)


### PR DESCRIPTION
If you specify none it will just try all available devices. This makes sure that it also works when no select box is added to choose the method (which is unnecessary if you force only one TOTP device per account).
