### PR TITLE
Reset login flow after navigating away for more security

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@ Changelog
 =========
 
 * Support custom ``User`` models.
+* Fixed a bug where a user could end up half logged in if they didn't complete
+  the two-factor login flow. A user's login flow will now be reset. Requires
+  enabled the included middle: ``allauth_2fa.middleware.AllauthTwoFactorMiddleware``.
 * Minor simplifications of code.
 * Minor updates to documentation.
 

--- a/README.rst
+++ b/README.rst
@@ -70,9 +70,9 @@ in-depth steps on their configuration.)
         # AuthenticationMiddleware.
         'django_otp.middleware.OTPMiddleware',
 
-        # If this middleware is enabled the login flow is reset if another page
-        # is loaded than. This makes sure someone does not stay half logged in
-        # without knowing.
+        # Reset login flow middleware. If this middleware is included, the login
+        # flow is reset if another page is loaded between login and successfully
+        # entering two-factor credentials.
         'allauth_2fa.middleware.AllauthTwoFactorMiddleware',
     )
 

--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,11 @@ in-depth steps on their configuration.)
         # Configure the django-otp package. Note this must be after the
         # AuthenticationMiddleware.
         'django_otp.middleware.OTPMiddleware',
+
+        # If this middleware is enabled the login flow is reset if another page
+        # is loaded than. This makes sure someone does not stay half logged in
+        # without knowing.
+        'allauth_2fa.middleware.AllauthTwoFactorMiddleware',
     )
 
     # Set the allauth adapter to be the 2FA adapter.

--- a/allauth_2fa/adapter.py
+++ b/allauth_2fa/adapter.py
@@ -11,7 +11,7 @@ class OTPAdapter(DefaultAccountAdapter):
 
         # Require two-factor authentication if it has been configured.
         if user.totpdevice_set.all():
-            request.session['user_id'] = user.id
+            request.session['allauth_2fa_user_id'] = user.id
             raise ImmediateHttpResponse(
                 response=HttpResponseRedirect(
                     reverse('two-factor-authenticate')

--- a/allauth_2fa/middleware.py
+++ b/allauth_2fa/middleware.py
@@ -2,7 +2,13 @@ from django.core.urlresolvers import resolve
 
 
 class AllauthTwoFactorMiddleware(object):
-    """Resets the login flow when another page is loaded halfway through."""
+    """
+    Reset the login flow if another page is loaded halfway through the login.
+    (I.e. if the user has logged in with a username/password, but not yet
+    entered their two-factor credentials.) This makes sure a user does not stay
+    half logged in by mistake.
+
+    """
 
     def process_request(self, request):
         if resolve(request.path).url_name != 'two-factor-authenticate':

--- a/allauth_2fa/middleware.py
+++ b/allauth_2fa/middleware.py
@@ -1,0 +1,12 @@
+from django.core.urlresolvers import resolve
+
+
+class AllauthTwoFactorMiddleware(object):
+    """Resets the login flow when another page is loaded halfway through."""
+
+    def process_request(self, request):
+        if resolve(request.path).url_name != 'two-factor-authenticate':
+            try:
+                del request.session['user_id']
+            except KeyError:
+                pass

--- a/allauth_2fa/middleware.py
+++ b/allauth_2fa/middleware.py
@@ -7,6 +7,6 @@ class AllauthTwoFactorMiddleware(object):
     def process_request(self, request):
         if resolve(request.path).url_name != 'two-factor-authenticate':
             try:
-                del request.session['user_id']
+                del request.session['allauth_2fa_user_id']
             except KeyError:
                 pass

--- a/allauth_2fa/views.py
+++ b/allauth_2fa/views.py
@@ -32,15 +32,11 @@ class TwoFactorAuthenticate(FormView):
     form_class = TOTPAuthenticateForm
     success_url = SUCCESS_URL
 
-    def get(self, request, *args, **kwargs):
+    def dispatch(self, request, *args, **kwargs):
         if 'allauth_2fa_user_id' not in request.session:
             return redirect('account_login')
-        return super(TwoFactorAuthenticate, self).get(request, *args, **kwargs)
-
-    def post(self, request, *args, **kwargs):
-        if 'allauth_2fa_user_id' not in request.session:
-            return redirect('account_login')
-        return super(TwoFactorAuthenticate, self).post(request, *args, **kwargs)
+        return super(TwoFactorAuthenticate, self).dispatch(request, *args,
+                                                           **kwargs)
 
     def get_form_kwargs(self):
         kwargs = super(TwoFactorAuthenticate, self).get_form_kwargs()

--- a/allauth_2fa/views.py
+++ b/allauth_2fa/views.py
@@ -8,6 +8,7 @@ except ImportError:
 from django.core.urlresolvers import reverse_lazy
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.shortcuts import redirect
 from django.contrib.sites.shortcuts import get_current_site
 from django.http import HttpResponseRedirect, HttpResponse
 from django.views.generic import FormView, View, TemplateView
@@ -30,6 +31,16 @@ class TwoFactorAuthenticate(FormView):
     template_name = 'allauth_2fa/authenticate.html'
     form_class = TOTPAuthenticateForm
     success_url = SUCCESS_URL
+
+    def get(self, request, *args, **kwargs):
+        if 'user_id' not in request.session:
+            return redirect('account_login')
+        return super(TwoFactorAuthenticate, self).get(request, *args, **kwargs)
+
+    def post(self, request, *args, **kwargs):
+        if 'user_id' not in request.session:
+            return redirect('account_login')
+        return super(TwoFactorAuthenticate, self).post(request, *args, **kwargs)
 
     def get_form_kwargs(self):
         kwargs = super(TwoFactorAuthenticate, self).get_form_kwargs()

--- a/allauth_2fa/views.py
+++ b/allauth_2fa/views.py
@@ -33,18 +33,18 @@ class TwoFactorAuthenticate(FormView):
     success_url = SUCCESS_URL
 
     def get(self, request, *args, **kwargs):
-        if 'user_id' not in request.session:
+        if 'allauth_2fa_user_id' not in request.session:
             return redirect('account_login')
         return super(TwoFactorAuthenticate, self).get(request, *args, **kwargs)
 
     def post(self, request, *args, **kwargs):
-        if 'user_id' not in request.session:
+        if 'allauth_2fa_user_id' not in request.session:
             return redirect('account_login')
         return super(TwoFactorAuthenticate, self).post(request, *args, **kwargs)
 
     def get_form_kwargs(self):
         kwargs = super(TwoFactorAuthenticate, self).get_form_kwargs()
-        user_id = self.request.session['user_id']
+        user_id = self.request.session['allauth_2fa_user_id']
         kwargs['user'] = get_user_model().objects.get(id=user_id)
         return kwargs
 

--- a/allauth_2fa/views.py
+++ b/allauth_2fa/views.py
@@ -8,17 +8,20 @@ except ImportError:
 from django.core.urlresolvers import reverse_lazy
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.shortcuts import redirect
 from django.contrib.sites.shortcuts import get_current_site
 from django.http import HttpResponseRedirect, HttpResponse
+from django.shortcuts import redirect
 from django.views.generic import FormView, View, TemplateView
+
 from django_otp.plugins.otp_static.models import StaticToken
 from django_otp.util import random_hex
 
 import qrcode
 from qrcode.image.svg import SvgPathImage
 
-from .forms import TOTPDeviceForm, TOTPDeviceRemoveForm, TOTPAuthenticateForm
+from allauth_2fa.forms import (TOTPDeviceForm,
+                               TOTPDeviceRemoveForm,
+                               TOTPAuthenticateForm)
 
 
 if hasattr(settings, 'LOGIN_REDIRECT_URL'):
@@ -33,6 +36,8 @@ class TwoFactorAuthenticate(FormView):
     success_url = SUCCESS_URL
 
     def dispatch(self, request, *args, **kwargs):
+        # If the user is not about to enter their two-factor credentials,
+        # redirect to the login page (they shouldn't be here!)
         if 'allauth_2fa_user_id' not in request.session:
             return redirect('account_login')
         return super(TwoFactorAuthenticate, self).dispatch(request, *args,

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = (
     # Enable allauth.
     'allauth',
     'allauth.account',
+    # Required to render the default template for 'account_login'.
     'allauth.socialaccount',
 
     # Configure the django-otp package.
@@ -66,7 +67,7 @@ MIDDLEWARE_CLASSES = (
     # Configure the django-otp package.
     'django_otp.middleware.OTPMiddleware',
 
-    # Reset login flow middleware
+    # Reset login flow middleware.
     'allauth_2fa.middleware.AllauthTwoFactorMiddleware',
 )
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = (
     # Enable allauth.
     'allauth',
     'allauth.account',
+    'allauth.socialaccount',
 
     # Configure the django-otp package.
     'django_otp',
@@ -64,6 +65,9 @@ MIDDLEWARE_CLASSES = (
 
     # Configure the django-otp package.
     'django_otp.middleware.OTPMiddleware',
+
+    # Reset login flow middleware
+    'allauth_2fa.middleware.AllauthTwoFactorMiddleware',
 )
 
 AUTHENTICATION_BACKENDS = (

--- a/tests/test_allauth_2fa.py
+++ b/tests/test_allauth_2fa.py
@@ -75,8 +75,10 @@ class Test2Factor(TestCase):
                              reverse('two-factor-authenticate'),
                              fetch_redirect_response=False)
 
+        self.assertIn('allauth_2fa_user_id', self.client.session)
         # Navigate back to login
         self.client.get(reverse('account_login'))
+        self.assertNotIn('allauth_2fa_user_id', self.client.session)
 
         # And try to continue with two-factor without logging in again
         resp = self.client.get(reverse('two-factor-authenticate'))


### PR DESCRIPTION
Right now if you log in and are redirected to the two-factor-authenticate and then navigate away you stay "half" logged in. At any point you can go back to the two-factor-authenticate page and it will allow you to log in with only the second factor, because you already entered the password before.

This change automatically resets the login flow state if another page is loaded then the two-factor-authenticate page. It also automatically redirects to the login page if you are not at the second factor stage (instead of crashing like it did before).
