### PR TITLE
Use built in confirmation and totp verification of django-otp

### DIFF
--- a/allauth_2fa/adapter.py
+++ b/allauth_2fa/adapter.py
@@ -10,7 +10,7 @@ class OTPAdapter(DefaultAccountAdapter):
     def login(self, request, user):
 
         # Require two-factor authentication if it has been configured.
-        if user.totpdevice_set.all():
+        if user.totpdevice_set.filter(confirmed=True).all():
             request.session['allauth_2fa_user_id'] = user.id
             raise ImmediateHttpResponse(
                 response=HttpResponseRedirect(

--- a/allauth_2fa/forms.py
+++ b/allauth_2fa/forms.py
@@ -1,10 +1,6 @@
-from binascii import unhexlify
-from time import time
-
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 from django_otp.forms import OTPAuthenticationFormMixin
-from django_otp.oath import totp
 from django_otp.plugins.otp_totp.models import TOTPDevice
 
 
@@ -31,59 +27,24 @@ class TOTPDeviceForm(forms.Form):
         label=_("Token"),
     )
 
-    def __init__(self, key, user, metadata=None, **kwargs):
+    def __init__(self, user, metadata=None, **kwargs):
         super(TOTPDeviceForm, self).__init__(**kwargs)
         self.fields['token'].widget.attrs.update({'autofocus': 'autofocus'})
-        self.key = key
-        self.tolerance = 1
-        self.t0 = 0
-        self.step = 30
-        self.drift = 0
-        self.digits = 6
         self.user = user
         self.metadata = metadata or {}
 
     def clean_token(self):
-        try:
-            token = int(self.cleaned_data.get('token'))
-        except ValueError:
-            # valid will never equal true in this case.
-            token = None
-        valid = False
-        t0s = [self.t0]
-        key = unhexlify(self.key.encode())
-        if 'valid_t0' in self.metadata:
-            t0s.append(int(time()) - self.metadata['valid_t0'])
-        for t0 in t0s:
-            for offset in range(-self.tolerance, self.tolerance):
-                expected_token = totp(
-                    key,
-                    self.step,
-                    t0,
-                    self.digits,
-                    self.drift + offset
-                )
+        token = self.cleaned_data.get('token')
+        self.device = self.user.totpdevice_set\
+            .filter(confirmed=False).first()
 
-                if expected_token == token:
-                    self.drift = offset
-                    self.metadata['valid_t0'] = int(time()) - t0
-                    valid = True
-
-        if not valid:
+        if not self.device.verify_token(token):
             raise forms.ValidationError(_('The entered token is not valid'))
         return token
 
     def save(self):
-        return TOTPDevice.objects.create(
-            user=self.user,
-            key=self.key,
-            tolerance=self.tolerance,
-            t0=self.t0,
-            step=self.step,
-            drift=self.drift,
-            digits=self.digits,
-            name='default'
-        )
+        self.user.totpdevice_set.filter(confirmed=True).delete()
+        return TOTPDevice.objects.create(user=self.user)
 
 
 class TOTPDeviceRemoveForm(forms.Form):

--- a/allauth_2fa/views.py
+++ b/allauth_2fa/views.py
@@ -5,10 +5,10 @@ try:
 except ImportError:
     from urllib import quote, urlencode
 
-from django.core.urlresolvers import reverse_lazy
 from django.conf import settings
-from django.contrib.auth import get_user_model
+from django.contrib.auth import get_user_model, login
 from django.contrib.sites.shortcuts import get_current_site
+from django.core.urlresolvers import reverse_lazy
 from django.http import HttpResponseRedirect, HttpResponse
 from django.shortcuts import redirect
 from django.views.generic import FormView, View, TemplateView
@@ -50,10 +50,8 @@ class TwoFactorAuthenticate(FormView):
         return kwargs
 
     def form_valid(self, form):
-        from django.contrib.auth import login
         if not hasattr(form.user, 'backend'):
-            form.user.backend \
-                = "allauth.account.auth_backends.AuthenticationBackend"
+            form.user.backend = "allauth.account.auth_backends.AuthenticationBackend"
         login(self.request, form.user)
         return super(TwoFactorAuthenticate, self).form_valid(form)
 

--- a/allauth_2fa/views.py
+++ b/allauth_2fa/views.py
@@ -74,7 +74,7 @@ class TwoFactorSetup(FormView):
 
         return super(TwoFactorSetup, self).dispatch(request, *args, **kwargs)
 
-    def get_form_kwargs(self, request):
+    def get_form_kwargs(self):
         kwargs = super(TwoFactorSetup, self).get_form_kwargs()
         kwargs['user'] = self.request.user
         return kwargs

--- a/tests/test_allauth_2fa.py
+++ b/tests/test_allauth_2fa.py
@@ -56,7 +56,7 @@ class Test2Factor(TestCase):
                              reverse('two-factor-authenticate'),
                              fetch_redirect_response=False)
 
-        # Now ensure that logging in actually works.
+        # Ensure that logging in does not work with invalid token
         resp = self.client.post(reverse('two-factor-authenticate'),
                                 {'otp_token': 'invalid'})
         self.assertEqual(resp.status_code, 200)


### PR DESCRIPTION
This method greatly simplifies the way the TOTP device is confirmed. Instead of keeping the key in the session a device is stored in the database that does not have the confirmed flag set. 

This allows usage of built in verification method of the TOTPDevice model to confirm the model. Which makes the code less complex and keeps security sensitive code in a single place (the django-otp library).

This method is also advised by the maintainer of django-otp: https://bitbucket.org/psagers/django-otp/pull-requests/22/move-totp-verification-code-to-regular/diff
