### PR TITLE
Make middleware more lenient to differently named urls

### DIFF
--- a/allauth_2fa/middleware.py
+++ b/allauth_2fa/middleware.py
@@ -11,7 +11,8 @@ class AllauthTwoFactorMiddleware(object):
     """
 
     def process_request(self, request):
-        if resolve(request.path).url_name != 'two-factor-authenticate':
+        if not resolve(request.path).url_name.startswith(
+                'two-factor-authenticate'):
             try:
                 del request.session['allauth_2fa_user_id']
             except KeyError:


### PR DESCRIPTION
In my implementation I have a more extensive login flow. This change allows to have mulitple urls to not reset the login flow. 
