### PR TITLE
Don't allow anonymous users to hit the 2fa views.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *.pyc
 __pycache__/
 *.sw*
-db.sqlite3
+db.sqlite
 .idea/
 .tox/
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,11 @@
 Changelog
 #########
 
+0.3.1 October 5, 2016
+=====================
+
+* Properly handle an ``AnonymousUser`` hitting the views.
+
 0.3 October 5, 2016
 ===================
 


### PR DESCRIPTION
Check if a user is anonymous before trying to touch `totpdevice_set`.

Fixes #28 
