### PR TITLE
Continue login flow from allauth after successful authentication

### DIFF
--- a/allauth_2fa/views.py
+++ b/allauth_2fa/views.py
@@ -192,7 +192,6 @@ class QRCodeGeneratorView(View):
 
         content_type = 'image/svg+xml; charset=utf-8'
         device = request.user.totpdevice_set.filter(confirmed=False).first()
-        print(device.id)
         secret_key = b32encode(device.bin_key).decode('utf-8')
         issuer = get_current_site(request).name
 


### PR DESCRIPTION
Allauth adds some functionality that can be used to handle login. Things like
signals, messages and redirection. This is currently skipped because this lib
breaks the login flow in the middle (like it should), but it does not continue
the flow afterwards.

This adds support for this functionality as good as is currently possible. It
misses support for the signal_kwargs and redirect_url parameters of
`perform_login`. This can probably only be added when this data is sent to the
login handler of the adapter. I only see this happening by either
sending a pull request to allauth or monkey patching it.

But without these extra features this pull request restores most of the
functionality already.
