### PR TITLE
Added Django 1.10 Middleware Mixin

### DIFF
--- a/allauth_2fa/middleware.py
+++ b/allauth_2fa/middleware.py
@@ -1,7 +1,8 @@
 from django.core.urlresolvers import resolve
+from django.utils.deprecation import MiddlewareMixin
 
 
-class AllauthTwoFactorMiddleware(object):
+class AllauthTwoFactorMiddleware(MiddlewareMixin):
     """
     Reset the login flow if another page is loaded halfway through the login.
     (I.e. if the user has logged in with a username/password, but not yet

--- a/allauth_2fa/middleware.py
+++ b/allauth_2fa/middleware.py
@@ -1,5 +1,8 @@
 from django.core.urlresolvers import resolve
-from django.utils.deprecation import MiddlewareMixin
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    MiddlewareMixin = object
 
 
 class AllauthTwoFactorMiddleware(MiddlewareMixin):


### PR DESCRIPTION
To make the middleware compatible with Django 1.10 this mixin needs to be added as per https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-middleware
