### PR TITLE
Fix exception when an unnamed view hits the middleware.

### DIFF
--- a/allauth_2fa/middleware.py
+++ b/allauth_2fa/middleware.py
@@ -16,7 +16,7 @@ class AllauthTwoFactorMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
         match = resolve(request.path)
-        if match.url_name and not match.url_name.startswith(
+        if not match.url_name or not match.url_name.startswith(
                 'two-factor-authenticate'):
             try:
                 del request.session['allauth_2fa_user_id']

--- a/allauth_2fa/middleware.py
+++ b/allauth_2fa/middleware.py
@@ -15,7 +15,8 @@ class AllauthTwoFactorMiddleware(MiddlewareMixin):
     """
 
     def process_request(self, request):
-        if not resolve(request.path).url_name.startswith(
+        match = resolve(request.path)
+        if match.url_name and not match.url_name.startswith(
                 'two-factor-authenticate'):
             try:
                 del request.session['allauth_2fa_user_id']

--- a/tests/test_allauth_2fa.py
+++ b/tests/test_allauth_2fa.py
@@ -168,6 +168,10 @@ class Test2Factor(TestCase):
         resp = self.client.get(reverse('two-factor-qr-code'))
         self.assertEqual(resp.status_code, 404)
 
+    def test_unnamed_view(self):
+        """Views without names should not throw an exception."""
+        resp = self.client.get('/unnamed-view')
+
 
 @unittest.skipIf(not MiddlewareMixin, 'Additional middleware tests are Django > 1.10.')
 @override_settings(MIDDLEWARE=settings.MIDDLEWARE_CLASSES, MIDDLEWARE_CLASSES=[])

--- a/tests/test_allauth_2fa.py
+++ b/tests/test_allauth_2fa.py
@@ -170,7 +170,34 @@ class Test2Factor(TestCase):
 
     def test_unnamed_view(self):
         """Views without names should not throw an exception."""
+        user = get_user_model().objects.create(username='john')
+        user.set_password('doe')
+        user.save()
+        user.totpdevice_set.create()
+
+        resp = self.client.post(reverse('account_login'),
+                                {'login': 'john',
+                                 'password': 'doe'})
+        self.assertRedirects(resp,
+                             reverse('two-factor-authenticate'),
+                             fetch_redirect_response=False)
+
+        # The user ID should be in the session.
+        self.assertIn('allauth_2fa_user_id', self.client.session)
+
+        # Navigate to a different (unnamed) page.
         resp = self.client.get('/unnamed-view')
+
+        # The middleware should reset the login flow.
+        self.assertNotIn('allauth_2fa_user_id', self.client.session)
+
+        # Trying to continue with two-factor without logging in again will
+        # redirect to login.
+        resp = self.client.get(reverse('two-factor-authenticate'))
+
+        self.assertRedirects(resp,
+                             reverse('account_login'),
+                             fetch_redirect_response=False)
 
 
 @unittest.skipIf(not MiddlewareMixin, 'Additional middleware tests are Django > 1.10.')

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,7 +1,12 @@
 from django.conf.urls import include, url
 
+from allauth_2fa import views
+
 urlpatterns = [
     # Include the allauth and 2FA urls from their respective packages.
     url(r'^accounts/', include('allauth_2fa.urls')),
     url(r'^accounts/', include('allauth.urls')),
+
+    # A view without a name.
+    url(r"^unnamed-view$", views.TwoFactorAuthenticate.as_view()),
 ]


### PR DESCRIPTION
Hitting an unnamed view currently raises an exception. This should be allowed (and it should reset the login flow).

Fixes #37