### PR TITLE
Update tox to reflect current versions.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,16 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = {py27,py34,py35}-django{18,19,110,111}
+envlist =
+    # django-otp 0.3.5 and django 1.8 are the earliest supported version.
+    py{27,34,35,36}-django{18,19}-dotp035,
+    # django-otp 0.3.6 added support for django 1.10.
+    py{27,34,35,36}-django{110,111}-dotp036,
+    # django-otp 0.3.8 added partial support for django 2.0 (which only supports
+    # Python 3.4+), but django-otp's otp_static plugin isn't compatible with
+    # Django 2.0 yet.
+    # py{34,35,36}-django20-dotp038
+skip_missing_interpreters = True
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
@@ -14,4 +23,8 @@ deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
-    django111: https://codeload.github.com/django/django/zip/master
+    django111: Django>=1.11a,<2.0
+    django20: https://codeload.github.com/django/django/zip/master
+    dotp035: django-otp==0.3.5
+    dotp036: django-otp==0.3.6
+    dotp038: django-otp==0.3.8


### PR DESCRIPTION
This should fix the builds for compatible versions across django, django-otp and python.