### PR TITLE
Support Django 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 # This version of python is only used to run tox.
-python: 3.5
+python: 3.6
 script: tox
 notifications:
   email: false

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,8 +12,9 @@ Changelog
   without enabling 2FA first.
 * Add base middleware to ensure particular users (e.g. superusers) have 2FA
   enabled.
-* Drop support for Django 1.9 and 1.10, they're
-  [no longer supported](https://www.djangoproject.com/download/#supported-versions).
+* Drop official support for Django 1.9 and 1.10, they're
+  [no longer supported](https://www.djangoproject.com/download/#supported-versions)
+  by the Django project.
 
 0.4.4 March 24, 2017
 ====================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,8 +3,8 @@
 Changelog
 #########
 
-0.4.5 xxxx
-==========
+0.5 xxxx
+========
 
 * Avoid an exception if a user without any configured devices tries to view a QR
   code. This view now properly 404s.
@@ -12,6 +12,8 @@ Changelog
   without enabling 2FA first.
 * Add base middleware to ensure particular users (e.g. superusers) have 2FA
   enabled.
+* Drop support for Django 1.9 and 1.10, they're
+  [no longer supported](https://www.djangoproject.com/download/#supported-versions).
 
 0.4.4 March 24, 2017
 ====================

--- a/allauth_2fa/adapter.py
+++ b/allauth_2fa/adapter.py
@@ -3,8 +3,11 @@ try:
 except ImportError:
     from urllib import urlencode
 
-from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 
 from allauth.exceptions import ImmediateHttpResponse
 from allauth.account.adapter import DefaultAccountAdapter

--- a/allauth_2fa/middleware.py
+++ b/allauth_2fa/middleware.py
@@ -1,7 +1,10 @@
 from django.shortcuts import redirect
 from django.conf import settings
 from django.contrib import messages
-from django.core.urlresolvers import resolve, reverse
+try:
+    from django.urls import resolve, reverse
+except ImportError:
+    from django.core.urlresolvers import resolve, reverse
 try:
     from django.utils.deprecation import MiddlewareMixin
 except ImportError:

--- a/allauth_2fa/middleware.py
+++ b/allauth_2fa/middleware.py
@@ -11,6 +11,7 @@ except ImportError:
     MiddlewareMixin = object
 
 from allauth.account.adapter import get_adapter
+from allauth.compat import is_anonymous
 
 
 class AllauthTwoFactorMiddleware(MiddlewareMixin):
@@ -93,7 +94,7 @@ class BaseRequire2FAMiddleware(MiddlewareMixin):
 
     def process_view(self, request, view_func, view_args, view_kwargs):
         # The user is not logged in, do nothing.
-        if request.user.is_anonymous():
+        if is_anonymous(request.user):
             return
 
         # If this doesn't require 2FA, then stop processing.

--- a/allauth_2fa/views.py
+++ b/allauth_2fa/views.py
@@ -8,9 +8,12 @@ from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.views import redirect_to_login
 from django.contrib.sites.shortcuts import get_current_site
-from django.core.urlresolvers import reverse_lazy, reverse
 from django.http import HttpResponseRedirect, HttpResponse, Http404
 from django.shortcuts import redirect
+try:
+    from django.urls import reverse_lazy, reverse
+except ImportError:
+    from django.core.urlresolvers import reverse_lazy, reverse
 from django.views.generic import FormView, View, TemplateView
 
 from django_otp.plugins.otp_static.models import StaticToken

--- a/allauth_2fa/views.py
+++ b/allauth_2fa/views.py
@@ -25,6 +25,7 @@ from qrcode.image.svg import SvgPathImage
 from allauth.account import signals
 from allauth.account.adapter import get_adapter
 from allauth.account.utils import get_login_redirect_url
+from allauth.compat import is_anonymous
 
 from allauth_2fa.adapter import OTPAdapter
 from allauth_2fa.forms import (TOTPDeviceForm,
@@ -96,7 +97,7 @@ class TwoFactorSetup(FormView):
     def dispatch(self, request, *args, **kwargs):
         # TODO Once Django 1.9 is the minimum supported version, see if we can
         # use LoginRequiredMixin.
-        if request.user.is_anonymous():
+        if is_anonymous(request.user):
             return redirect_to_login(self.request.get_full_path())
 
         # If the user has 2FA setup already, redirect them to the backup tokens.
@@ -145,7 +146,7 @@ class TwoFactorRemove(FormView):
     def dispatch(self, request, *args, **kwargs):
         # TODO Once Django 1.9 is the minimum supported version, see if we can
         # use LoginRequiredMixin.
-        if request.user.is_anonymous():
+        if is_anonymous(request.user):
             return redirect_to_login(self.request.get_full_path())
 
         if request.user.totpdevice_set.exists():
@@ -169,7 +170,7 @@ class TwoFactorBackupTokens(TemplateView):
     def dispatch(self, request, *args, **kwargs):
         # TODO Once Django 1.9 is the minimum supported version, see if we can
         # use LoginRequiredMixin.
-        if request.user.is_anonymous():
+        if is_anonymous(request.user):
             return redirect_to_login(self.request.get_full_path())
 
         if request.user.totpdevice_set.exists():
@@ -204,7 +205,7 @@ class QRCodeGeneratorView(View):
 
     def get(self, request, *args, **kwargs):
         # Anonymous users can't have a TOTP device configured.
-        if request.user.is_anonymous():
+        if is_anonymous(request.user):
             raise Http404()
 
         device = request.user.totpdevice_set.filter(confirmed=False).first()

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,3 +1,5 @@
+import django
+
 SECRET_KEY = 'not_empty'
 SITE_ID = 1
 ALLOWED_HOSTS = ['*']
@@ -57,11 +59,10 @@ INSTALLED_APPS = (
     'tests',
 )
 
-MIDDLEWARE_CLASSES = (
+MW = (
     # Configure Django auth package.
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
 
     # Configure the django-otp package.
     'django_otp.middleware.OTPMiddleware',
@@ -69,6 +70,14 @@ MIDDLEWARE_CLASSES = (
     # Reset login flow middleware.
     'allauth_2fa.middleware.AllauthTwoFactorMiddleware',
 )
+
+if django.VERSION < (2,):
+    MW += ('django.contrib.auth.middleware.SessionAuthenticationMiddleware',)
+
+if django.VERSION > (1, 10):
+    MIDDLEWARE = MW
+else:
+    MIDDLEWARE_CLASSES = MW
 
 AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.ModelBackend',

--- a/tests/test_allauth_2fa.py
+++ b/tests/test_allauth_2fa.py
@@ -4,8 +4,11 @@ import unittest
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
-from django.core.urlresolvers import reverse
 from django.test import override_settings, TestCase
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 try:
     from django.utils.deprecation import MiddlewareMixin
 except ImportError:

--- a/tox.ini
+++ b/tox.ini
@@ -6,14 +6,14 @@
 [tox]
 envlist =
     # django-otp 0.3.5 and Django 1.8 are the earliest supported version.
-    py{27,34,35,36}-django{18,19}-dotp035,
+    py{27,34,35,36}-django{18,19}-dotp{035,036,0312,04,dotpmaster},
     # django-otp 0.3.6 added support for Django 1.10.
-    py{27,34,35,36}-django{110,111}-dotp036,
+    py{27,34,35,36}-django{110,111}-dotp{036,0312,04,dotpmaster},
     # django-otp 0.3.12 added support for Django 1.11 and django 2.0. Django 2.0
     # drops support for Python 2.7.
-    py{34,35,36}-django20-dotp0312
+    py{34,35,36}-django20-dotp{0312,04,dotpmaster}
     # Django master drops support for Python 3.4.
-    py{35,36}-djangomaster-dotp0312
+    py{35,36}-djangomaster-dotp{0312,04,dotpmaster}
 skip_missing_interpreters = True
 
 [testenv]
@@ -30,3 +30,5 @@ deps =
     dotp035: django-otp==0.3.5
     dotp036: django-otp==0.3.6
     dotp0312: django-otp==0.3.12
+    dotp04: django-otp>=0.4
+    dotpmaster: hg+https://bitbucket.org/psagers/django-otp#egg=subdir&subdirectory=django-otp

--- a/tox.ini
+++ b/tox.ini
@@ -5,14 +5,15 @@
 
 [tox]
 envlist =
-    # django-otp 0.3.5 and django 1.8 are the earliest supported version.
+    # django-otp 0.3.5 and Django 1.8 are the earliest supported version.
     py{27,34,35,36}-django{18,19}-dotp035,
-    # django-otp 0.3.6 added support for django 1.10.
+    # django-otp 0.3.6 added support for Django 1.10.
     py{27,34,35,36}-django{110,111}-dotp036,
-    # django-otp 0.3.8 added partial support for django 2.0 (which only supports
-    # Python 3.4+), but django-otp's otp_static plugin isn't compatible with
-    # Django 2.0 yet.
-    # py{34,35,36}-django20-dotp038
+    # django-otp 0.3.12 added support for Django 1.11 and django 2.0. Django 2.0
+    # drops support for Python 2.7.
+    py{34,35,36}-django20-dotp0312
+    # Django master drops support for Python 3.4.
+    py{35,36}-djangomaster-dotp0312
 skip_missing_interpreters = True
 
 [testenv]
@@ -24,7 +25,8 @@ deps =
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
     django111: Django>=1.11a,<2.0
-    django20: https://codeload.github.com/django/django/zip/master
+    django20: Django>=2.0a1,<2.1
+    djangomaster: https://codeload.github.com/django/django/zip/master
     dotp035: django-otp==0.3.5
     dotp036: django-otp==0.3.6
-    dotp038: django-otp==0.3.8
+    dotp0312: django-otp==0.3.12

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps =
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
     django111: Django>=1.11a,<2.0
-    django20: Django>=2.0a1,<2.1
+    django20: Django>=2.0,<2.1
     djangomaster: https://codeload.github.com/django/django/zip/master
     dotp035: django-otp==0.3.5
     dotp036: django-otp==0.3.6

--- a/tox.ini
+++ b/tox.ini
@@ -6,14 +6,14 @@
 [tox]
 envlist =
     # django-otp 0.3.5 and Django 1.8 are the earliest supported version.
-    py{27,34,35,36}-django{18,19}-dotp{035,036,0312,04,dotpmaster},
+    py{27,34,35,36}-django18-dotp{03,04,dotpmaster},
     # django-otp 0.3.6 added support for Django 1.10.
-    py{27,34,35,36}-django{110,111}-dotp{036,0312,04,dotpmaster},
+    py{27,34,35,36}-django111-dotp{03,04,dotpmaster},
     # django-otp 0.3.12 added support for Django 1.11 and django 2.0. Django 2.0
     # drops support for Python 2.7.
-    py{34,35,36}-django20-dotp{0312,04,dotpmaster}
+    py{34,35,36}-django20-dotp{03,04,dotpmaster}
     # Django master drops support for Python 3.4.
-    py{35,36}-djangomaster-dotp{0312,04,dotpmaster}
+    py{35,36}-djangomaster-dotp{03,04,dotpmaster}
 skip_missing_interpreters = True
 
 [testenv]
@@ -22,13 +22,9 @@ commands =
     python manage.py test
 deps =
     django18: Django>=1.8,<1.9
-    django19: Django>=1.9,<1.10
-    django110: Django>=1.10,<1.11
     django111: Django>=1.11a,<2.0
     django20: Django>=2.0,<2.1
     djangomaster: https://codeload.github.com/django/django/zip/master
-    dotp035: django-otp==0.3.5
-    dotp036: django-otp==0.3.6
-    dotp0312: django-otp==0.3.12
-    dotp04: django-otp>=0.4
+    dotp03: django-otp>=0.3,<0.4
+    dotp04: django-otp>=0.4,<0.5
     dotpmaster: hg+https://bitbucket.org/psagers/django-otp#egg=subdir&subdirectory=django-otp

--- a/tox.ini
+++ b/tox.ini
@@ -6,14 +6,13 @@
 [tox]
 envlist =
     # django-otp 0.3.5 and Django 1.8 are the earliest supported version.
-    py{27,34,35,36}-django18-dotp{03,04,dotpmaster},
     # django-otp 0.3.6 added support for Django 1.10.
-    py{27,34,35,36}-django111-dotp{03,04,dotpmaster},
+    py{27,34,35,36}-django{18,111}-dotp{03,04,master},
     # django-otp 0.3.12 added support for Django 1.11 and django 2.0. Django 2.0
     # drops support for Python 2.7.
-    py{34,35,36}-django20-dotp{03,04,dotpmaster}
+    py{34,35,36}-django20-dotp{03,04,master}
     # Django master drops support for Python 3.4.
-    py{35,36}-djangomaster-dotp{03,04,dotpmaster}
+    py{35,36}-djangomaster-dotp{03,04,master}
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Updates tox configuration and makes the following changes:
* Adds support Django 2.0
* Drops support for Django 1.9 and 1.10. (They should still work, but aren't being tested anymore, they're no longer supported by Django.)