### PR TITLE
Don't raise an exception for users without a TOTP device configured.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ Changelog
 
 * Avoid an exception if a user without any configured devices tries to view a QR
   code. This view now properly 404s.
+* Redirect users to configure 2FA is they attempt to configure backup tokens
+  without enabling 2FA first.
 
 0.4.4 March 24, 2017
 ====================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,12 @@
 Changelog
 #########
 
+0.4.5 xxxx
+==========
+
+* Avoid an exception if a user without any configured devices tries to view a QR
+  code. This view now properly 404s.
+
 0.4.4 March 24, 2017
 ====================
 

--- a/allauth_2fa/views.py
+++ b/allauth_2fa/views.py
@@ -8,7 +8,7 @@ from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.views import redirect_to_login
 from django.contrib.sites.shortcuts import get_current_site
-from django.core.urlresolvers import reverse_lazy
+from django.core.urlresolvers import reverse_lazy, reverse
 from django.http import HttpResponseRedirect, HttpResponse, Http404
 from django.shortcuts import redirect
 from django.views.generic import FormView, View, TemplateView
@@ -98,7 +98,7 @@ class TwoFactorSetup(FormView):
 
         # If the user has 2FA setup already, redirect them to the backup tokens.
         if request.user.totpdevice_set.filter(confirmed=True).exists():
-            return HttpResponseRedirect(reverse_lazy('two-factor-backup-tokens'))
+            return HttpResponseRedirect(reverse('two-factor-backup-tokens'))
 
         return super(TwoFactorSetup, self).dispatch(request, *args, **kwargs)
 
@@ -148,7 +148,7 @@ class TwoFactorRemove(FormView):
         if request.user.totpdevice_set.exists():
             return super(TwoFactorRemove, self).dispatch(request, *args, **kwargs)
         else:
-            return HttpResponseRedirect(reverse_lazy('two-factor-setup'))
+            return HttpResponseRedirect(reverse('two-factor-setup'))
 
     def form_valid(self, form):
         form.save()
@@ -169,7 +169,10 @@ class TwoFactorBackupTokens(TemplateView):
         if request.user.is_anonymous():
             return redirect_to_login(self.request.get_full_path())
 
-        return super(TwoFactorBackupTokens, self).dispatch(request, *args, **kwargs)
+        if request.user.totpdevice_set.exists():
+            return super(TwoFactorBackupTokens, self).dispatch(request, *args, **kwargs)
+        else:
+            return HttpResponseRedirect(reverse('two-factor-setup'))
 
     def get_context_data(self, **kwargs):
         context = super(TwoFactorBackupTokens, self).get_context_data(*kwargs)

--- a/tests/test_allauth_2fa.py
+++ b/tests/test_allauth_2fa.py
@@ -249,6 +249,25 @@ class Test2Factor(TestCase):
         # Ensure the signal is received as expected.
         self.assertEqual(self.user_logged_in_count, 1)
 
+    def test_qr_code_anonymous(self):
+        """The QR code should not error for anonymous users."""
+        resp = self.client.get(reverse('two-factor-qr-code'))
+        self.assertEqual(resp.status_code, 404)
+
+    def test_qr_code_no_device(self):
+        """The QR code should not error for users that don't have TOTP devices."""
+        user = get_user_model().objects.create(username='john')
+        user.set_password('doe')
+        user.save()
+
+        # Login first.
+        self.client.post(reverse('account_login'),
+                         {'login': 'john',
+                          'password': 'doe'})
+
+        # Then try to get the QR code.
+        resp = self.client.get(reverse('two-factor-qr-code'))
+        self.assertEqual(resp.status_code, 404)
 
 @unittest.skipIf(not MiddlewareMixin, 'Additional middleware tests are Django > 1.10.')
 @override_settings(MIDDLEWARE=settings.MIDDLEWARE_CLASSES, MIDDLEWARE_CLASSES=[])

--- a/tests/test_allauth_2fa.py
+++ b/tests/test_allauth_2fa.py
@@ -249,6 +249,24 @@ class Test2Factor(TestCase):
         # Ensure the signal is received as expected.
         self.assertEqual(self.user_logged_in_count, 1)
 
+    def test_not_configured_redirect(self):
+        """Viewing backup codes or disabling 2FA should redirect if 2FA is not configured."""
+        user = get_user_model().objects.create(username='john')
+        user.set_password('doe')
+        user.save()
+
+        # Login
+        resp = self.client.post(reverse('account_login'),
+                                {'login': 'john',
+                                 'password': 'doe'})
+
+        # The 2FA pages should redirect.
+        for url_name in ['two-factor-backup-tokens', 'two-factor-remove']:
+            resp = self.client.get(reverse(url_name))
+            self.assertRedirects(resp,
+                                 reverse('two-factor-setup'),
+                                 fetch_redirect_response=False)
+
     def test_qr_code_anonymous(self):
         """The QR code should not error for anonymous users."""
         resp = self.client.get(reverse('two-factor-qr-code'))


### PR DESCRIPTION
The QR code view shouldn't raise an exception if a user tries to get that view without a TOTP device configured. The only way I could reproduce this was by directing loading this, but it's possible something weird could happen if you have multiple pages open and was adding / removing devices.

There's a separate issue that I'm going to fix in a minute where you can get to the backup tokens page even if 2FA is not configured.