### PR TITLE
Install and run flake8 for style checking

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,12 @@
+[flake8]
+ignore =
+    # We put new lines between different packages for imports.
+    I202
+exclude =
+    .git,
+    __pycache__,
+    # The * import causes lots of false positives.
+    tests/run_settings.py
+max-line-length = 150
+application-import-names = allauth_2fa, manage, tests
+import-order-style = appnexus

--- a/.flake8
+++ b/.flake8
@@ -4,6 +4,7 @@ ignore =
     I202
 exclude =
     .git,
+    .tox,
     __pycache__,
     # The * import causes lots of false positives.
     tests/run_settings.py

--- a/allauth_2fa/adapter.py
+++ b/allauth_2fa/adapter.py
@@ -3,14 +3,14 @@ try:
 except ImportError:
     from urllib import urlencode
 
+from allauth.account.adapter import DefaultAccountAdapter
+from allauth.exceptions import ImmediateHttpResponse
+
 from django.http import HttpResponseRedirect
 try:
     from django.urls import reverse
 except ImportError:
     from django.core.urlresolvers import reverse
-
-from allauth.exceptions import ImmediateHttpResponse
-from allauth.account.adapter import DefaultAccountAdapter
 
 
 class OTPAdapter(DefaultAccountAdapter):

--- a/allauth_2fa/middleware.py
+++ b/allauth_2fa/middleware.py
@@ -1,4 +1,6 @@
-from django.shortcuts import redirect
+from allauth.account.adapter import get_adapter
+from allauth.compat import is_anonymous
+
 from django.conf import settings
 from django.contrib import messages
 try:
@@ -9,9 +11,7 @@ try:
     from django.utils.deprecation import MiddlewareMixin
 except ImportError:
     MiddlewareMixin = object
-
-from allauth.account.adapter import get_adapter
-from allauth.compat import is_anonymous
+from django.shortcuts import redirect
 
 
 class AllauthTwoFactorMiddleware(MiddlewareMixin):

--- a/allauth_2fa/views.py
+++ b/allauth_2fa/views.py
@@ -4,17 +4,22 @@ try:
 except ImportError:
     from urllib import quote, urlencode
 
+from allauth.account import signals
+from allauth.account.adapter import get_adapter
+from allauth.account.utils import get_login_redirect_url
+from allauth.compat import is_anonymous
+
 from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.views import redirect_to_login
 from django.contrib.sites.shortcuts import get_current_site
-from django.http import HttpResponseRedirect, HttpResponse, Http404
+from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.shortcuts import redirect
 try:
     from django.urls import reverse_lazy, reverse
 except ImportError:
     from django.core.urlresolvers import reverse_lazy, reverse
-from django.views.generic import FormView, View, TemplateView
+from django.views.generic import FormView, TemplateView, View
 
 from django_otp.plugins.otp_static.models import StaticToken
 from django_otp.plugins.otp_totp.models import TOTPDevice
@@ -22,15 +27,10 @@ from django_otp.plugins.otp_totp.models import TOTPDevice
 import qrcode
 from qrcode.image.svg import SvgPathImage
 
-from allauth.account import signals
-from allauth.account.adapter import get_adapter
-from allauth.account.utils import get_login_redirect_url
-from allauth.compat import is_anonymous
-
 from allauth_2fa.adapter import OTPAdapter
-from allauth_2fa.forms import (TOTPDeviceForm,
-                               TOTPDeviceRemoveForm,
-                               TOTPAuthenticateForm)
+from allauth_2fa.forms import (TOTPAuthenticateForm,
+                               TOTPDeviceForm,
+                               TOTPDeviceRemoveForm)
 
 
 class TwoFactorAuthenticate(FormView):

--- a/manage.py
+++ b/manage.py
@@ -2,7 +2,7 @@
 import os
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'tests.settings')
 
-from django.core import management
-
 if __name__ == "__main__":
+    from django.core import management
+
     management.execute_from_command_line()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 # for installing the package and running unit tests are defined in setup.py.
 -e .
 
-
 django>=1.11
 django-allauth==0.26.1
 django-otp==0.4.1
@@ -13,3 +12,7 @@ django-extensions==1.7.4
 ipdb==0.10.1
 ipython==5.1.0
 Werkzeug==0.11.11
+
+# Style checking.
+flake8==3.5.0
+flake8-import-order==0.16

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,13 @@
 
 import codecs
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
+
 
 def long_description():
     with codecs.open('README.rst', encoding='utf8') as f:
         return f.read()
+
 
 setup(
     name="django-allauth-2fa",

--- a/tests/test_allauth_2fa.py
+++ b/tests/test_allauth_2fa.py
@@ -1,10 +1,8 @@
-from copy import deepcopy
-import unittest
+from allauth.account.signals import user_logged_in
 
 import django
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import AnonymousUser
 from django.test import override_settings, TestCase
 try:
     from django.urls import reverse
@@ -14,8 +12,6 @@ try:
     from django.utils.deprecation import MiddlewareMixin
 except ImportError:
     MiddlewareMixin = None
-
-from allauth.account.signals import user_logged_in
 
 from django_otp.oath import TOTP
 
@@ -83,7 +79,7 @@ class Test2Factor(TestCase):
         user = get_user_model().objects.create(username='john')
         user.set_password('doe')
         user.save()
-        totp_model = user.totpdevice_set.create()
+        user.totpdevice_set.create()
 
         resp = self.client.post(reverse('account_login'),
                                 {'login': 'john',
@@ -164,7 +160,7 @@ class Test2Factor(TestCase):
         user = get_user_model().objects.create(username='john')
         user.set_password('doe')
         user.save()
-        totp_model = user.totpdevice_set.create()
+        user.totpdevice_set.create()
 
         # Add a next to unnamed-view.
         resp = self.client.post(reverse('account_login') + '?next=unnamed-view',
@@ -181,8 +177,6 @@ class Test2Factor(TestCase):
         """
         Views should not be hittable via an AnonymousUser.
         """
-        user = AnonymousUser()
-
         # The authentication page redirects to the login page.
         url = reverse('two-factor-authenticate')
         resp = self.client.get(url)

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,6 +1,7 @@
 from django.conf.urls import include, url
 from django.http import HttpResponse
 
+
 def blank_view(request):
     return HttpResponse("<h1>HELLO WORLD!</h1>")
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,12 +7,14 @@
 envlist =
     # django-otp 0.3.5 and Django 1.8 are the earliest supported version.
     # django-otp 0.3.6 added support for Django 1.10.
-    py{27,34,35,36}-django{18,111}-dotp{03,04,master},
+    py{27,34,35,36}-django{18,111}-dotp{03,04,master}
     # django-otp 0.3.12 added support for Django 1.11 and django 2.0. Django 2.0
     # drops support for Python 2.7.
     py{34,35,36}-django20-dotp{03,04,master}
     # Django master drops support for Python 3.4.
     py{35,36}-djangomaster-dotp{03,04,master}
+    # Check code style.
+    flake8
 skip_missing_interpreters = True
 
 [testenv]
@@ -30,6 +32,14 @@ deps =
     dotp03: django-otp>=0.3,<0.4
     dotp04: django-otp>=0.4,<0.5
     dotpmaster: hg+https://bitbucket.org/psagers/django-otp#egg=subdir&subdirectory=django-otp
+
+[testenv:flake8]
+skip_install = True
+deps =
+    flake8
+    flake8-import-order
+commands =
+    flake8
 
 [coverage:run]
 include = allauth_2fa*

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ deps =
     flake8
     flake8-import-order
 commands =
-    flake8
+    flake8 {toxinidir}
 
 [coverage:run]
 include = allauth_2fa*


### PR DESCRIPTION
Installs flake8 and flake8-import-order and runs them as part of tox. This also fixes the issues that flake8 found, most of which were import order + a couple of unused variables/imports in tests.