### PR TITLE
Add compatibility with django-allauth 0.35.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,12 @@
 Changelog
 #########
 
+0.6 xxx xx, 2018
+================
+
+* Drop support for Django < 1.11, these are no longer supported by
+  django-allauth (as of 0.35.0).
+
 0.5 December 21, 2017
 =====================
 

--- a/allauth_2fa/middleware.py
+++ b/allauth_2fa/middleware.py
@@ -1,5 +1,4 @@
 from allauth.account.adapter import get_adapter
-from allauth.compat import is_anonymous
 
 from django.conf import settings
 from django.contrib import messages
@@ -94,7 +93,7 @@ class BaseRequire2FAMiddleware(MiddlewareMixin):
 
     def process_view(self, request, view_func, view_args, view_kwargs):
         # The user is not logged in, do nothing.
-        if is_anonymous(request.user):
+        if request.user.is_anonymous:
             return
 
         # If this doesn't require 2FA, then stop processing.

--- a/allauth_2fa/views.py
+++ b/allauth_2fa/views.py
@@ -7,7 +7,6 @@ except ImportError:
 from allauth.account import signals
 from allauth.account.adapter import get_adapter
 from allauth.account.utils import get_login_redirect_url
-from allauth.compat import is_anonymous
 
 from django.contrib import messages
 from django.contrib.auth import get_user_model
@@ -97,7 +96,7 @@ class TwoFactorSetup(FormView):
     def dispatch(self, request, *args, **kwargs):
         # TODO Once Django 1.9 is the minimum supported version, see if we can
         # use LoginRequiredMixin.
-        if is_anonymous(request.user):
+        if request.user.is_anonymous:
             return redirect_to_login(self.request.get_full_path())
 
         # If the user has 2FA setup already, redirect them to the backup tokens.
@@ -146,7 +145,7 @@ class TwoFactorRemove(FormView):
     def dispatch(self, request, *args, **kwargs):
         # TODO Once Django 1.9 is the minimum supported version, see if we can
         # use LoginRequiredMixin.
-        if is_anonymous(request.user):
+        if request.user.is_anonymous:
             return redirect_to_login(self.request.get_full_path())
 
         if request.user.totpdevice_set.exists():
@@ -170,7 +169,7 @@ class TwoFactorBackupTokens(TemplateView):
     def dispatch(self, request, *args, **kwargs):
         # TODO Once Django 1.9 is the minimum supported version, see if we can
         # use LoginRequiredMixin.
-        if is_anonymous(request.user):
+        if request.user.is_anonymous:
             return redirect_to_login(self.request.get_full_path())
 
         if request.user.totpdevice_set.exists():
@@ -205,7 +204,7 @@ class QRCodeGeneratorView(View):
 
     def get(self, request, *args, **kwargs):
         # Anonymous users can't have a TOTP device configured.
-        if is_anonymous(request.user):
+        if request.user.is_anonymous:
             raise Http404()
 
         device = request.user.totpdevice_set.filter(confirmed=False).first()

--- a/tox.ini
+++ b/tox.ini
@@ -5,11 +5,9 @@
 
 [tox]
 envlist =
-    # django-otp 0.3.5 and Django 1.8 are the earliest supported version.
-    # django-otp 0.3.6 added support for Django 1.10.
-    py{27,34,35,36}-django{18,111}-dotp{03,04,master}
-    # django-otp 0.3.12 added support for Django 1.11 and django 2.0. Django 2.0
-    # drops support for Python 2.7.
+    # django-otp 0.3.12 and Django 1.11 are the earliest supported version.
+    py{27,34,35,36}-django111-dotp{03,04,master}
+    # Django 2.0 drops support for Python 2.7.
     py{34,35,36}-django20-dotp{03,04,master}
     # Django master drops support for Python 3.4.
     py{35,36}-djangomaster-dotp{03,04,master}
@@ -25,8 +23,7 @@ commands =
     coverage html
 deps =
     coverage
-    django18: Django>=1.8,<1.9
-    django111: Django>=1.11a,<2.0
+    django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
     djangomaster: https://codeload.github.com/django/django/zip/master
     dotp03: django-otp>=0.3,<0.4


### PR DESCRIPTION
django-allauth 0.35.0 dropped support for Django < 1.11, breaking compatibility with django-allauth-2fa. This restores compatibility.

Fixes #60