### PR TITLE
Remove obsolete code, support Django 2.0/2.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,12 @@
 Changelog
 #########
 
+next
+====
+
+* Remove more code that was for Django < 1.11.
+* Officially support Django 2.0 and Django 2.1.
+
 0.6 February 13, 2018
 =====================
 

--- a/allauth_2fa/adapter.py
+++ b/allauth_2fa/adapter.py
@@ -7,10 +7,7 @@ from allauth.account.adapter import DefaultAccountAdapter
 from allauth.exceptions import ImmediateHttpResponse
 
 from django.http import HttpResponseRedirect
-try:
-    from django.urls import reverse
-except ImportError:
-    from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 
 class OTPAdapter(DefaultAccountAdapter):

--- a/allauth_2fa/middleware.py
+++ b/allauth_2fa/middleware.py
@@ -2,15 +2,9 @@ from allauth.account.adapter import get_adapter
 
 from django.conf import settings
 from django.contrib import messages
-try:
-    from django.urls import resolve, reverse
-except ImportError:
-    from django.core.urlresolvers import resolve, reverse
-try:
-    from django.utils.deprecation import MiddlewareMixin
-except ImportError:
-    MiddlewareMixin = object
 from django.shortcuts import redirect
+from django.urls import resolve, reverse
+from django.utils.deprecation import MiddlewareMixin
 
 
 class AllauthTwoFactorMiddleware(MiddlewareMixin):

--- a/allauth_2fa/views.py
+++ b/allauth_2fa/views.py
@@ -14,10 +14,7 @@ from django.contrib.auth.views import redirect_to_login
 from django.contrib.sites.shortcuts import get_current_site
 from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.shortcuts import redirect
-try:
-    from django.urls import reverse_lazy, reverse
-except ImportError:
-    from django.core.urlresolvers import reverse_lazy, reverse
+from django.urls import reverse, reverse_lazy
 from django.views.generic import FormView, TemplateView, View
 
 from django_otp.plugins.otp_static.models import StaticToken

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -59,7 +59,7 @@ INSTALLED_APPS = (
     'tests',
 )
 
-MW = (
+MIDDLEWARE = (
     # Configure Django auth package.
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -72,12 +72,7 @@ MW = (
 )
 
 if django.VERSION < (2,):
-    MW += ('django.contrib.auth.middleware.SessionAuthenticationMiddleware',)
-
-if django.VERSION > (1, 10):
-    MIDDLEWARE = MW
-else:
-    MIDDLEWARE_CLASSES = MW
+    MIDDLEWARE += ('django.contrib.auth.middleware.SessionAuthenticationMiddleware',)
 
 AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.ModelBackend',

--- a/tests/test_allauth_2fa.py
+++ b/tests/test_allauth_2fa.py
@@ -1,27 +1,13 @@
 from allauth.account.signals import user_logged_in
 
-import django
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import override_settings, TestCase
-try:
-    from django.urls import reverse
-except ImportError:
-    from django.core.urlresolvers import reverse
-try:
-    from django.utils.deprecation import MiddlewareMixin
-except ImportError:
-    MiddlewareMixin = None
+from django.urls import reverse
 
 from django_otp.oath import TOTP
 
 from allauth_2fa.middleware import BaseRequire2FAMiddleware
-
-
-if django.VERSION > (1, 10):
-    MIDDLEWARE_VAR = 'MIDDLEWARE'
-else:
-    MIDDLEWARE_VAR = 'MIDDLEWARE_CLASSES'
 
 
 class Test2Factor(TestCase):
@@ -303,7 +289,7 @@ class Require2FA(BaseRequire2FAMiddleware):
     # Don't redirect to an "allowed" URL.
     LOGIN_REDIRECT_URL='/unnamed-view',
     # Add the middleware that requires 2FA.
-    **{MIDDLEWARE_VAR: getattr(settings, MIDDLEWARE_VAR) + ('tests.test_allauth_2fa.Require2FA',)}
+    MIDDLEWARE=settings.MIDDLEWARE + ('tests.test_allauth_2fa.Require2FA',)
 )
 class TestRequire2FAMiddleware(TestCase):
     def test_no_2fa(self):
@@ -348,10 +334,10 @@ class TestRequire2FAMiddleware(TestCase):
         INSTALLED_APPS=settings.INSTALLED_APPS + ('django.contrib.messages', ),
         # This doesn't seem to stack nicely with the class-based one, so add the
         # middleware here.
-        **{MIDDLEWARE_VAR: getattr(settings, MIDDLEWARE_VAR) + (
+        MIDDLEWARE=settings.MIDDLEWARE + (
             'tests.test_allauth_2fa.Require2FA',
             'django.contrib.messages.middleware.MessageMiddleware',
-        )}
+        ),
     )
     def test_no_2fa_messages(self):
         """Test login behavior when 2FA is not configured and the messages framework is in use."""

--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,11 @@ envlist =
     # django-otp 0.3.12 and Django 1.11 are the earliest supported version.
     py{27,34,35,36}-django111-dotp{03,04,master}
     # Django 2.0 drops support for Python 2.7.
-    py{34,35,36}-django20-dotp{03,04,master}
+    py{34,35,36}-django20-dotp{03,04}
+    # django-otp 0.5 adds support for Django 2.1
+    py{35,36}-django21-dotp{05,master}
     # Django master drops support for Python 3.4.
-    py{35,36}-djangomaster-dotp{03,04,master}
+    py{35,36}-djangomaster-dotp{03,04,05,master}
     # Check code style.
     flake8
 skip_missing_interpreters = True
@@ -25,9 +27,11 @@ deps =
     coverage
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
+    django21: Django>=2.1,<2.2
     djangomaster: https://codeload.github.com/django/django/zip/master
     dotp03: django-otp>=0.3,<0.4
     dotp04: django-otp>=0.4,<0.5
+    dotp05: django-otp>=0.5,<0.6
     dotpmaster: hg+https://bitbucket.org/psagers/django-otp#egg=subdir&subdirectory=django-otp
 
 [testenv:flake8]


### PR DESCRIPTION
This removes some more code that was unused for Django < 1.11. It also adds Django 2.0 and 2.1 and django-otp 0.5 to the testing matrix.