### PR TITLE
Issue #64, cast user.id to string in session 

### DIFF
--- a/allauth_2fa/adapter.py
+++ b/allauth_2fa/adapter.py
@@ -18,7 +18,7 @@ class OTPAdapter(DefaultAccountAdapter):
     def login(self, request, user):
         # Require two-factor authentication if it has been configured.
         if self.has_2fa_enabled(user):
-            request.session['allauth_2fa_user_id'] = user.id
+            request.session['allauth_2fa_user_id'] = str(user.id)
 
             redirect_url = reverse('two-factor-authenticate')
             # Add GET parameters to the URL if they exist.


### PR DESCRIPTION
#64 

When a User model uses UUIDs as the PK, it was causing a TypeError when the session middleware would try to serialize into JSON.  We cast the user.id to a string to try to avoid this.

Thanks for all of your work on this library!