### PR TITLE
Miscellaneous fixes and improvements

### DIFF
--- a/allauth_2fa/adapter.py
+++ b/allauth_2fa/adapter.py
@@ -1,3 +1,5 @@
+from allauth_2fa.utils import user_has_valid_totp_device
+
 try:
     from urllib.parse import urlencode
 except ImportError:
@@ -13,7 +15,7 @@ from django.urls import reverse
 class OTPAdapter(DefaultAccountAdapter):
     def has_2fa_enabled(self, user):
         """Returns True if the user has 2FA configured."""
-        return user.totpdevice_set.filter(confirmed=True).exists()
+        return user_has_valid_totp_device(user)
 
     def login(self, request, user):
         # Require two-factor authentication if it has been configured.

--- a/allauth_2fa/adapter.py
+++ b/allauth_2fa/adapter.py
@@ -1,3 +1,8 @@
+from allauth.account.adapter import DefaultAccountAdapter
+from allauth.exceptions import ImmediateHttpResponse
+from django.http import HttpResponseRedirect
+from django.urls import reverse
+
 from allauth_2fa.utils import user_has_valid_totp_device
 
 try:
@@ -5,11 +10,7 @@ try:
 except ImportError:
     from urllib import urlencode
 
-from allauth.account.adapter import DefaultAccountAdapter
-from allauth.exceptions import ImmediateHttpResponse
 
-from django.http import HttpResponseRedirect
-from django.urls import reverse
 
 
 class OTPAdapter(DefaultAccountAdapter):

--- a/allauth_2fa/adapter.py
+++ b/allauth_2fa/adapter.py
@@ -11,8 +11,6 @@ except ImportError:
     from urllib import urlencode
 
 
-
-
 class OTPAdapter(DefaultAccountAdapter):
     def has_2fa_enabled(self, user):
         """Returns True if the user has 2FA configured."""

--- a/allauth_2fa/adapter.py
+++ b/allauth_2fa/adapter.py
@@ -19,7 +19,7 @@ class OTPAdapter(DefaultAccountAdapter):
 
     def login(self, request, user):
         # Require two-factor authentication if it has been configured.
-        if self.has_2fa_enabled(user):
+        if self.has_2fa_enabled(user) and not getattr(user, 'otp_device', None):
             request.session['allauth_2fa_user_id'] = user.id
 
             redirect_url = reverse('two-factor-authenticate')

--- a/allauth_2fa/forms.py
+++ b/allauth_2fa/forms.py
@@ -1,7 +1,6 @@
 from django import forms
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils.translation import ugettext_lazy as _
-
 from django_otp.forms import OTPAuthenticationFormMixin
 from django_otp.plugins.otp_totp.models import TOTPDevice
 

--- a/allauth_2fa/forms.py
+++ b/allauth_2fa/forms.py
@@ -1,8 +1,11 @@
 from django import forms
+from django.core.exceptions import ObjectDoesNotExist
 from django.utils.translation import ugettext_lazy as _
 
 from django_otp.forms import OTPAuthenticationFormMixin
 from django_otp.plugins.otp_totp.models import TOTPDevice
+
+from allauth_2fa import settings
 
 
 class TOTPAuthenticateForm(OTPAuthenticationFormMixin, forms.Form):
@@ -62,9 +65,13 @@ class TOTPDeviceRemoveForm(forms.Form):
 
     def save(self):
         # Delete any backup tokens.
-        static_device = self.user.staticdevice_set.get(name='backup')
-        static_device.token_set.all().delete()
-        static_device.delete()
+        try:
+            static_device = self.user.staticdevice_set.get(name=settings.BACKUP_DEVICE_NAME)
+        except ObjectDoesNotExist:
+            pass
+        else:
+            static_device.token_set.all().delete()
+            static_device.delete()
 
         # Delete TOTP device.
         device = TOTPDevice.objects.get(user=self.user)

--- a/allauth_2fa/middleware.py
+++ b/allauth_2fa/middleware.py
@@ -1,5 +1,4 @@
 from allauth.account.adapter import get_adapter
-
 from django.conf import settings
 from django.contrib import messages
 from django.shortcuts import redirect

--- a/allauth_2fa/mixins.py
+++ b/allauth_2fa/mixins.py
@@ -1,0 +1,19 @@
+from django.contrib.auth.mixins import AccessMixin
+from django.http import HttpResponseRedirect
+from django.urls import reverse_lazy
+
+from allauth_2fa.utils import user_has_valid_totp_device
+
+
+class ValidTOTPDeviceRequiredMixin(AccessMixin):
+    no_valid_totp_device_url = reverse_lazy('two-factor-setup')
+
+    def dispatch(self, request, *args, **kwargs):
+        if not request.user.is_authenticated:
+            return self.handle_no_permission()
+        if not user_has_valid_totp_device(request.user):
+            return self.handle_missing_totp_device()
+        return super(ValidTOTPDeviceRequiredMixin, self).dispatch(request, *args, **kwargs)
+
+    def handle_missing_totp_device(self):
+        return HttpResponseRedirect(self.no_valid_totp_device_url)

--- a/allauth_2fa/settings.py
+++ b/allauth_2fa/settings.py
@@ -2,3 +2,4 @@ from allauth.account import app_settings
 from django.conf import settings
 
 TEMPLATE_EXTENSION = getattr(settings, 'ALLAUTH_2FA_TEMPLATE_EXTENSION', app_settings.TEMPLATE_EXTENSION)
+BACKUP_DEVICE_NAME = getattr(settings, 'ALLAUTH_2FA_BACKUP_DEVICE_NAME', 'backup')

--- a/allauth_2fa/settings.py
+++ b/allauth_2fa/settings.py
@@ -4,3 +4,4 @@ from django.conf import settings
 TEMPLATE_EXTENSION = getattr(settings, 'ALLAUTH_2FA_TEMPLATE_EXTENSION', app_settings.TEMPLATE_EXTENSION)
 BACKUP_DEVICE_NAME = getattr(settings, 'ALLAUTH_2FA_BACKUP_DEVICE_NAME', 'backup')
 BACKUP_TOKEN_COUNT = int(getattr(settings, 'ALLAUTH_2FA_BACKUP_TOKEN_COUNT', 3))
+ALWAYS_REVEAL_BACKUP_TOKENS = bool(getattr(settings, 'ALLAUTH_2FA_ALWAYS_REVEAL_BACKUP_TOKENS', True))

--- a/allauth_2fa/settings.py
+++ b/allauth_2fa/settings.py
@@ -3,3 +3,4 @@ from django.conf import settings
 
 TEMPLATE_EXTENSION = getattr(settings, 'ALLAUTH_2FA_TEMPLATE_EXTENSION', app_settings.TEMPLATE_EXTENSION)
 BACKUP_DEVICE_NAME = getattr(settings, 'ALLAUTH_2FA_BACKUP_DEVICE_NAME', 'backup')
+BACKUP_TOKEN_COUNT = int(getattr(settings, 'ALLAUTH_2FA_BACKUP_TOKEN_COUNT', 3))

--- a/allauth_2fa/settings.py
+++ b/allauth_2fa/settings.py
@@ -1,0 +1,4 @@
+from allauth.account import app_settings
+from django.conf import settings
+
+TEMPLATE_EXTENSION = getattr(settings, 'ALLAUTH_2FA_TEMPLATE_EXTENSION', app_settings.TEMPLATE_EXTENSION)

--- a/allauth_2fa/templates/allauth_2fa/backup_tokens.html
+++ b/allauth_2fa/templates/allauth_2fa/backup_tokens.html
@@ -6,15 +6,19 @@
   {% trans "Two-Factor Authentication Backup Tokens" %}
 </h1>
 
-<ul>
-  {% for token in backup_tokens %}
-  <li>{{ token.token }}</li>
-
-  {% empty %}
+{% if backup_tokens %}
+  {% if reveal_tokens %}
+    <ul>
+      {% for token in backup_tokens %}
+        <li>{{ token.token }}</li>
+      {% endfor %}
+    </ul>
+  {% else %}
+    {% trans 'Backup tokens have been generated, but are not revealed here for security reasons. Press the button below to generate new ones.' %}
+  {% endif %}
+{% else %}
   {% trans 'No tokens. Press the button below to generate some.' %}
-
-  {% endfor %}
-</ul>
+{% endif %}
 
 <form method="post">
   {% csrf_token %}

--- a/allauth_2fa/urls.py
+++ b/allauth_2fa/urls.py
@@ -2,7 +2,6 @@ from django.conf.urls import url
 
 from allauth_2fa import views
 
-
 urlpatterns = [
     url(r"^two-factor-authenticate/?$",
         views.TwoFactorAuthenticate.as_view(),

--- a/allauth_2fa/utils.py
+++ b/allauth_2fa/utils.py
@@ -1,3 +1,31 @@
+from base64 import b32encode
+from urllib.parse import quote, urlencode
+
+import qrcode
+from django.utils.six import BytesIO
+from qrcode.image.svg import SvgPathImage
+
+
+def generate_totp_config_svg(device, issuer, label):
+    params = {
+        'secret': b32encode(device.bin_key).decode('utf-8'),
+        'algorithm': 'SHA1',
+        'digits': device.digits,
+        'period': device.step,
+        'issuer': issuer,
+    }
+
+    otpauth_url = 'otpauth://totp/{label}?{query}'.format(
+        label=quote(label),
+        query=urlencode(params),
+    )
+
+    img = qrcode.make(otpauth_url, image_factory=SvgPathImage)
+    io = BytesIO()
+    img.save(io)
+    return io.getvalue()
+
+
 def user_has_valid_totp_device(user):
     return (
         user.is_authenticated and

--- a/allauth_2fa/utils.py
+++ b/allauth_2fa/utils.py
@@ -10,7 +10,6 @@ except ImportError:
     from urllib import quote, urlencode
 
 
-
 def generate_totp_config_svg(device, issuer, label):
     params = {
         'secret': b32encode(device.bin_key).decode('utf-8'),
@@ -32,7 +31,6 @@ def generate_totp_config_svg(device, issuer, label):
 
 
 def user_has_valid_totp_device(user):
-    return (
-        user.is_authenticated and
-        user.totpdevice_set.filter(confirmed=True).exists()
-    )
+    if not user.is_authenticated:
+        return False
+    return user.totpdevice_set.filter(confirmed=True).exists()

--- a/allauth_2fa/utils.py
+++ b/allauth_2fa/utils.py
@@ -1,9 +1,14 @@
 from base64 import b32encode
-from urllib.parse import quote, urlencode
 
-import qrcode
 from django.utils.six import BytesIO
+import qrcode
 from qrcode.image.svg import SvgPathImage
+
+try:
+    from urllib.parse import quote, urlencode
+except ImportError:
+    from urllib import quote, urlencode
+
 
 
 def generate_totp_config_svg(device, issuer, label):

--- a/allauth_2fa/utils.py
+++ b/allauth_2fa/utils.py
@@ -1,0 +1,5 @@
+def user_has_valid_totp_device(user):
+    return (
+        user.is_authenticated and
+        user.totpdevice_set.filter(confirmed=True).exists()
+    )

--- a/allauth_2fa/views.py
+++ b/allauth_2fa/views.py
@@ -153,6 +153,9 @@ class TwoFactorRemove(ValidTOTPDeviceRequiredMixin, FormView):
 class TwoFactorBackupTokens(ValidTOTPDeviceRequiredMixin, TemplateView):
     template_name = 'allauth_2fa/backup_tokens.' + settings.TEMPLATE_EXTENSION
     token_count = settings.BACKUP_TOKEN_COUNT
+    # This can be overridden in a subclass to True,
+    # to have that particular view always reveal the tokens.
+    reveal_tokens = bool(settings.ALWAYS_REVEAL_BACKUP_TOKENS)
 
     def get_context_data(self, **kwargs):
         context = super(TwoFactorBackupTokens, self).get_context_data(**kwargs)
@@ -165,6 +168,7 @@ class TwoFactorBackupTokens(ValidTOTPDeviceRequiredMixin, TemplateView):
 
         if static_device:
             context['backup_tokens'] = static_device.token_set.all()
+            context['reveal_tokens'] = self.reveal_tokens
 
         return context
 
@@ -175,6 +179,7 @@ class TwoFactorBackupTokens(ValidTOTPDeviceRequiredMixin, TemplateView):
         static_device.token_set.all().delete()
         for _ in range(self.token_count):
             static_device.token_set.create(token=StaticToken.random_token())
+        self.reveal_tokens = True
         return self.get(request, *args, **kwargs)
 
 

--- a/allauth_2fa/views.py
+++ b/allauth_2fa/views.py
@@ -1,32 +1,33 @@
-import django_otp
+from allauth.account import app_settings
+from allauth.account.utils import get_next_redirect_url, perform_login
+from django.contrib.auth import get_user_model
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.contrib.sites.shortcuts import get_current_site
 from django.core.exceptions import ObjectDoesNotExist
+from django.http import Http404, HttpResponse, HttpResponseRedirect
+from django.shortcuts import redirect
+from django.urls import reverse, reverse_lazy
+from django.views.generic import FormView, TemplateView, View
+import django_otp
+from django_otp.plugins.otp_static.models import StaticToken
+from django_otp.plugins.otp_totp.models import TOTPDevice
 
+from allauth_2fa import settings
+from allauth_2fa.forms import (TOTPAuthenticateForm,
+                               TOTPDeviceForm,
+                               TOTPDeviceRemoveForm)
 from allauth_2fa.mixins import ValidTOTPDeviceRequiredMixin
+from allauth_2fa.utils import (generate_totp_config_svg,
+                               user_has_valid_totp_device)
 
 try:
     from urllib.parse import quote, urlencode
 except ImportError:
     from urllib import quote, urlencode
 
-from allauth.account import app_settings
-from allauth.account.utils import perform_login, get_next_redirect_url
 
-from django.contrib.auth import get_user_model
-from django.contrib.auth.mixins import LoginRequiredMixin
-from django.contrib.sites.shortcuts import get_current_site
-from django.http import Http404, HttpResponse, HttpResponseRedirect
-from django.shortcuts import redirect
-from django.urls import reverse, reverse_lazy
-from django.views.generic import FormView, TemplateView, View
 
-from django_otp.plugins.otp_static.models import StaticToken
-from django_otp.plugins.otp_totp.models import TOTPDevice
 
-from allauth_2fa.forms import (TOTPAuthenticateForm,
-                               TOTPDeviceForm,
-                               TOTPDeviceRemoveForm)
-from allauth_2fa import settings
-from allauth_2fa.utils import generate_totp_config_svg, user_has_valid_totp_device
 
 
 class TwoFactorAuthenticate(FormView):

--- a/allauth_2fa/views.py
+++ b/allauth_2fa/views.py
@@ -20,15 +20,6 @@ from allauth_2fa.mixins import ValidTOTPDeviceRequiredMixin
 from allauth_2fa.utils import (generate_totp_config_svg,
                                user_has_valid_totp_device)
 
-try:
-    from urllib.parse import quote, urlencode
-except ImportError:
-    from urllib import quote, urlencode
-
-
-
-
-
 
 class TwoFactorAuthenticate(FormView):
     template_name = 'allauth_2fa/authenticate.' + settings.TEMPLATE_EXTENSION
@@ -57,7 +48,7 @@ class TwoFactorAuthenticate(FormView):
         return (
             get_next_redirect_url(
                 self.request,
-                self.redirect_field_name) or
+                self.redirect_field_name) or  # noqa
             self.success_url
         )
 

--- a/allauth_2fa/views.py
+++ b/allauth_2fa/views.py
@@ -1,4 +1,5 @@
 from base64 import b32encode
+
 try:
     from urllib.parse import quote, urlencode
 except ImportError:
@@ -27,10 +28,10 @@ from allauth_2fa.adapter import OTPAdapter
 from allauth_2fa.forms import (TOTPAuthenticateForm,
                                TOTPDeviceForm,
                                TOTPDeviceRemoveForm)
-
+from allauth_2fa import settings
 
 class TwoFactorAuthenticate(FormView):
-    template_name = 'allauth_2fa/authenticate.html'
+    template_name = 'allauth_2fa/authenticate.' + settings.TEMPLATE_EXTENSION
     form_class = TOTPAuthenticateForm
 
     def dispatch(self, request, *args, **kwargs):
@@ -86,7 +87,7 @@ class TwoFactorAuthenticate(FormView):
 
 
 class TwoFactorSetup(FormView):
-    template_name = 'allauth_2fa/setup.html'
+    template_name = 'allauth_2fa/setup.' + settings.TEMPLATE_EXTENSION
     form_class = TOTPDeviceForm
     success_url = reverse_lazy('two-factor-backup-tokens')
 
@@ -135,7 +136,7 @@ class TwoFactorSetup(FormView):
 
 
 class TwoFactorRemove(FormView):
-    template_name = 'allauth_2fa/remove.html'
+    template_name = 'allauth_2fa/remove.' + settings.TEMPLATE_EXTENSION
     form_class = TOTPDeviceRemoveForm
     success_url = reverse_lazy('two-factor-setup')
 
@@ -161,7 +162,7 @@ class TwoFactorRemove(FormView):
 
 
 class TwoFactorBackupTokens(TemplateView):
-    template_name = 'allauth_2fa/backup_tokens.html'
+    template_name = 'allauth_2fa/backup_tokens.' + settings.TEMPLATE_EXTENSION
 
     def dispatch(self, request, *args, **kwargs):
         # TODO Once Django 1.9 is the minimum supported version, see if we can

--- a/allauth_2fa/views.py
+++ b/allauth_2fa/views.py
@@ -107,7 +107,7 @@ class TwoFactorSetup(LoginRequiredMixin, FormView):
         if the confirmation of the device fails.
         """
         self.request.user.totpdevice_set.filter(confirmed=False).delete()
-        TOTPDevice.objects.create(user=self.request.user, confirmed=False)
+        self.device = TOTPDevice.objects.create(user=self.request.user, confirmed=False)
 
     def get(self, request, *args, **kwargs):
         # Whenever this page is loaded, create a new device (this ensures a

--- a/allauth_2fa/views.py
+++ b/allauth_2fa/views.py
@@ -179,7 +179,7 @@ class TwoFactorBackupTokens(TemplateView):
             return HttpResponseRedirect(reverse('two-factor-setup'))
 
     def get_context_data(self, **kwargs):
-        context = super(TwoFactorBackupTokens, self).get_context_data(*kwargs)
+        context = super(TwoFactorBackupTokens, self).get_context_data(**kwargs)
         try:
             static_device = self.request.user.staticdevice_set.get(
                 name=settings.BACKUP_DEVICE_NAME

--- a/allauth_2fa/views.py
+++ b/allauth_2fa/views.py
@@ -165,6 +165,7 @@ class TwoFactorRemove(FormView):
 
 class TwoFactorBackupTokens(TemplateView):
     template_name = 'allauth_2fa/backup_tokens.' + settings.TEMPLATE_EXTENSION
+    token_count = settings.BACKUP_TOKEN_COUNT
 
     def dispatch(self, request, *args, **kwargs):
         # TODO Once Django 1.9 is the minimum supported version, see if we can
@@ -196,7 +197,7 @@ class TwoFactorBackupTokens(TemplateView):
             name=settings.BACKUP_DEVICE_NAME
         )
         static_device.token_set.all().delete()
-        for _ in range(3):
+        for _ in range(self.token_count):
             static_device.token_set.create(token=StaticToken.random_token())
         return self.get(request, *args, **kwargs)
 

--- a/allauth_2fa/views.py
+++ b/allauth_2fa/views.py
@@ -197,19 +197,21 @@ class QRCodeGeneratorView(LoginRequiredMixin, View):
         if not device:
             raise Http404()
 
-        secret_key = b32encode(device.bin_key).decode('utf-8')
         issuer = get_current_site(request).name
+        params = {
+            'secret': b32encode(device.bin_key).decode('utf-8'),
+            'algorithm': 'SHA1',
+            'digits': device.digits,
+            'period': device.step,
+        }
+        label = '{issuer}: {username}'.format(
+            issuer=issuer,
+            username=request.user.get_username()
+        )
 
         otpauth_url = 'otpauth://totp/{label}?{query}'.format(
-            label=quote('{issuer}: {username}'.format(
-                issuer=issuer,
-                username=request.user.get_username()
-            )),
-            query=urlencode((
-                ('secret', secret_key),
-                ('digits', device.get_digits_display()),
-                ('issuer', issuer),
-            ))
+            label=quote(label),
+            query=urlencode(params),
         )
 
         img = qrcode.make(otpauth_url, image_factory=SvgPathImage)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,7 @@
 
     installation
     advanced
+    settings
     changelog
 
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -11,3 +11,11 @@ Defaults to `ACCOUNT_TEMPLATE_EXTENSION` from Allauth, which
 is ``html`` by default.
 
 This can be used to allow a different template engine for 2FA views.
+
+
+``ALLAUTH_2FA_BACKUP_DEVICE_NAME``
+----------------------------------
+
+Set the name for the static backup code OTP device.
+
+Defaults to ``backup``.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -28,3 +28,11 @@ The number of backup tokens to create in the built-in backup
 code view.
 
 Defaults to 3.
+
+``ALLAUTH_2FA_ALWAYS_REVEAL_BACKUP_TOKENS``
+-------------------------------------------
+
+Whether to always show the remaining backup tokens on the
+Backup Tokens view, or only when they're freshly generated.
+
+Defaults to ``True``.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -19,3 +19,12 @@ This can be used to allow a different template engine for 2FA views.
 Set the name for the static backup code OTP device.
 
 Defaults to ``backup``.
+
+
+``ALLAUTH_2FA_BACKUP_TOKEN_COUNT``
+----------------------------------
+
+The number of backup tokens to create in the built-in backup
+code view.
+
+Defaults to 3.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1,0 +1,13 @@
+Settings
+--------
+
+``ALLAUTH_2FA_TEMPLATE_EXTENSION``
+----------------------------------
+
+ALlows you to override the extension for the templates used
+by `django-allauth-2fa`'s internal views.
+
+Defaults to `ACCOUNT_TEMPLATE_EXTENSION` from Allauth, which
+is ``html`` by default.
+
+This can be used to allow a different template engine for 2FA views.

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,12 @@ universal=1
 
 [metadata]
 license_file = LICENSE
+
+[isort]
+atomic = true
+combine_as_imports = false
+force_sort_within_sections = true
+line_length = 70
+multi_line_output = 1
+not_skip = __init__.py
+wrap_length = 70


### PR DESCRIPTION
We're using this package at @valohai for TOTP 2FA (a big thank you first of all!).

This PR contains some fixes, configurability improvements and other things I came across today while integrating this in our product.

# Features

* Support for other template engines than Django's by changing the template extension from `html`. This defaults to using Allauth's template extension setting.
* Configurable static backup device name.
* Configurable static backup token count.
* Configurable hiding of static backup tokens after their initial generation.

# Refactoring

* A new mixin, `allauth_2fa.mixins.ValidTOTPDeviceRequiredMixin` is now available and used in the builtin views.
* QR code generation was moved to an utility function. Our version of the token-adding view uses a `data:` URI for the QR code instead of calling out to a separate view to generate the QR code.
* The `perform_login()` copy-pasted logic is no longer required in the authentication view; as a side effect, `user.otp_device` is now always populated (by way of the `otp_device_id` session key provided by `django-otp`).

# Bugfixes

* The TOTP config URL is created a little more specifically (following what `TOTPDevice.config_url` does).
* A simple `*kwargs` -> `**kwargs` typo was fixed.


