### PR TITLE
Do not build django-otp master for now.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,8 @@ deps =
     dotp03: django-otp>=0.3,<0.4
     dotp04: django-otp>=0.4,<0.5
     dotp05: django-otp>=0.5,<0.6
-    dotpmaster: hg+https://bitbucket.org/psagers/django-otp#egg=subdir&subdirectory=django-otp
+    # pip seems to be having issues installing from BitBucket at the moment.
+    # dotpmaster: hg+https://bitbucket.org/psagers/django-otp#egg=subdir&subdirectory=django-otp
 
 [testenv:flake8]
 skip_install = True

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,8 @@ deps =
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
-    djangomaster: https://codeload.github.com/django/django/zip/master
+    # Django master builds are failing at the moment.
+    # djangomaster: https://codeload.github.com/django/django/zip/master
     dotp03: django-otp>=0.3,<0.4
     dotp04: django-otp>=0.4,<0.5
     dotp05: django-otp>=0.5,<0.6


### PR DESCRIPTION
pip is erroring when trying to install via hg from BitBucket. Not really sure why this is happening, but we still test against other versions of django-otp so this should be OK for now.