### PR TITLE
Update Python, Django and django-otp versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
+dist: xenial
 language: python
-# This version of python is only used to run tox.
-python: 3.6
+python:
+  - 3.7
+  - 3.6
+  - 2.7
+
+env:
+  - TOX_SKIP_ENV=".*djangomaster.*"
+  - TOX_SKIP_ENV=".*django[^m].*"
 
 cache:
   directories:
@@ -14,6 +21,9 @@ install:
   - pip install coveralls tox
 
 matrix:
+  exclude:
+    - python: 2.7
+      env: TOX_SKIP_ENV=".*django[^m].*"
   allow_failures:
     - env: TOX_SKIP_ENV=".*django[^m].*"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ notifications:
 install:
   - pip install coveralls tox
 
+matrix:
+  allow_failures:
+    - env: TOX_SKIP_ENV=".*django[^m].*"
+
 script:
   - tox
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ envlist =
     # Django 2.0 drops support for Python 2.7.
     py{35,36}-django20-dotp{03,04}
     # django-otp 0.5 adds support for Django 2.1
-    py{35,36}-django{21,22,master}-dotp{05,master}
+    py{35,36}-django{21,22,master}-dotp{05,06,master}
     # Check code style.
     flake8
 skip_missing_interpreters = True
@@ -33,6 +33,7 @@ deps =
     dotp04: django-otp>=0.4,<0.5
     dotp05: django-otp>=0.5,<0.6
     # pip seems to be having issues installing from BitBucket at the moment.
+    dotp06: django-otp>=0.6,<0.7
     # dotpmaster: hg+https://bitbucket.org/psagers/django-otp#egg=subdir&subdirectory=django-otp
 
 [testenv:flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -6,13 +6,11 @@
 [tox]
 envlist =
     # django-otp 0.3.12 and Django 1.11 are the earliest supported version.
-    py{27,34,35,36}-django111-dotp{03,04,master}
+    py{27,35,36}-django111-dotp{03,04,master}
     # Django 2.0 drops support for Python 2.7.
-    py{34,35,36}-django20-dotp{03,04}
+    py{35,36}-django20-dotp{03,04}
     # django-otp 0.5 adds support for Django 2.1
-    py{35,36}-django21-dotp{05,master}
-    # Django master drops support for Python 3.4.
-    py{35,36}-djangomaster-dotp{03,04,05,master}
+    py{35,36}-django{21,22,master}-dotp{05,master}
     # Check code style.
     flake8
 skip_missing_interpreters = True
@@ -28,8 +26,9 @@ deps =
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
+    django22: Django>=2.2,<2.3
     # Django master builds are failing at the moment.
-    # djangomaster: https://codeload.github.com/django/django/zip/master
+    djangomaster: https://codeload.github.com/django/django/zip/master
     dotp03: django-otp>=0.3,<0.4
     dotp04: django-otp>=0.4,<0.5
     dotp05: django-otp>=0.5,<0.6

--- a/tox.ini
+++ b/tox.ini
@@ -6,11 +6,13 @@
 [tox]
 envlist =
     # django-otp 0.3.12 and Django 1.11 are the earliest supported version.
-    py{27,35,36}-django111-dotp{03,04,master}
+    py{27,35,36,37}-django111-dotp{03,04,master}
     # Django 2.0 drops support for Python 2.7.
-    py{35,36}-django20-dotp{03,04}
+    py{35,36,37}-django20-dotp{03,04}
     # django-otp 0.5 adds support for Django 2.1
-    py{35,36}-django{21,22,master}-dotp{05,06,master}
+    py{35,36,37}-django{21,22}-dotp{05,06,master}
+    # Django master requires Python 3.6.
+    py{36,37}-djangomaster-dotp{05,06,master}
     # Check code style.
     flake8
 skip_missing_interpreters = True


### PR DESCRIPTION
Updates versions of Python:
* Drops 3.4
* Adds 3.7

Adds django-otp 0.6.*

Adds Django 2.2.*

Splits the build up by Python version