### PR TITLE
Replace django.utils.six with six

### DIFF
--- a/allauth_2fa/utils.py
+++ b/allauth_2fa/utils.py
@@ -5,10 +5,11 @@ except ImportError:
     from urllib import quote, urlencode
 
 from django.contrib.sites.shortcuts import get_current_site
-from six import BytesIO
 
 import qrcode
 from qrcode.image.svg import SvgPathImage
+
+from six import BytesIO
 
 
 def generate_totp_config_svg(device, issuer, label):

--- a/allauth_2fa/utils.py
+++ b/allauth_2fa/utils.py
@@ -5,7 +5,7 @@ except ImportError:
     from urllib import quote, urlencode
 
 from django.contrib.sites.shortcuts import get_current_site
-from django.utils.six import BytesIO
+from six import BytesIO
 
 import qrcode
 from qrcode.image.svg import SvgPathImage

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ django>=1.11
 django-allauth==0.26.1
 django-otp==0.4.1
 qrcode==5.3
+six==1.13.0
 
 # Nice for development.
 django-extensions==1.7.4

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         "qrcode>=5.3",
         "django-allauth>=0.25",
         "django-otp>=0.3.12",
+        "six==1.13.0",
     ],
     author="Víðir Valberg Guðmundsson",
     author_email="valberg@orn.li",


### PR DESCRIPTION
A possible fix for #84 (I hope), 

I've replaced the django.utils.six with the six library as recommended by[ Django documentation](https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis) for this depreciation as a workaround. 

I was able to run all tests both with Django 1.11 and Django 3.0 (Python 2.7 and 3.7).


