### PR TITLE
Fix Travis configuration to use the proper Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 dist: xenial
 language: python
 python:
+  - 3.8
   - 3.7
   - 3.6
-  - 2.7
 
 env:
   - TOX_SKIP_ENV=".*djangomaster.*"
@@ -21,9 +21,6 @@ install:
   - pip install coveralls tox
 
 matrix:
-  exclude:
-    - python: 2.7
-      env: TOX_SKIP_ENV=".*django[^m].*"
   allow_failures:
     - env: TOX_SKIP_ENV=".*django[^m].*"
 

--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,7 @@ below:
 * Django 1.11
 * django-allauth 0.25.0
 * django-otp 0.3.12
+* Python 3.5
 
 Contributing
 ------------

--- a/tox.ini
+++ b/tox.ini
@@ -6,9 +6,10 @@
 [tox]
 envlist =
     # django-otp 0.3.12 and Django 1.11 are the earliest supported version.
-    py{35,36,37}-django111-dotp{03,04,master}
+    # django-allauth 0.41.0 dropped support for Django 1.11.
+    py{35,36,37}-django111-dotp{03,04,master}-allauth40,
     # django-otp 0.5 adds support for Django 2.1
-    py{35,36,37}-django22-dotp{05,06,07,master}
+    py{35,36,37}-django22-dotp{05,06,07,master},
     # Django 3.0 requires Python 3.6.
     # django-otp 0.7 adds support for Django 3.0.
     py{36,37}-django{30,master}-dotp{07,master}
@@ -34,6 +35,7 @@ deps =
     dotp05: django-otp>=0.5,<0.6
     dotp06: django-otp>=0.6,<0.7
     dotp07: django-otp>=0.7,<0.8
+    allauth40: django-allauth<0.41.0
     dotpmaster: https://codeload.github.com/django-otp/django-otp/zip/master
 
 [testenv:flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -9,10 +9,10 @@ envlist =
     # django-allauth 0.41.0 dropped support for Django 1.11.
     py{35,36,37,38}-django111-dotp{03,04,master}-allauth40,
     # django-otp 0.5 adds support for Django 2.1
-    py{35,36,37,38}-django22-dotp{05,06,07,master},
+    py{35,36,37,38}-django22-dotp{05,06,07,master}-allauth41,
     # Django 3.0 requires Python 3.6.
     # django-otp 0.7 adds support for Django 3.0.
-    py{36,37,38}-django{30,master}-dotp{07,master}
+    py{36,37,38}-django{30,master}-dotp{07,master}-allauth41,
     # Check code style.
     flake8
 skip_missing_interpreters = True
@@ -36,6 +36,7 @@ deps =
     dotp06: django-otp>=0.6,<0.7
     dotp07: django-otp>=0.7,<0.8
     allauth40: django-allauth<0.41.0
+    allauth41: django-allauth>=0.41.0
     dotpmaster: https://codeload.github.com/django-otp/django-otp/zip/master
 
 [testenv:flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -7,12 +7,12 @@
 envlist =
     # django-otp 0.3.12 and Django 1.11 are the earliest supported version.
     # django-allauth 0.41.0 dropped support for Django 1.11.
-    py{35,36,37}-django111-dotp{03,04,master}-allauth40,
+    py{35,36,37,38}-django111-dotp{03,04,master}-allauth40,
     # django-otp 0.5 adds support for Django 2.1
-    py{35,36,37}-django22-dotp{05,06,07,master},
+    py{35,36,37,38}-django22-dotp{05,06,07,master},
     # Django 3.0 requires Python 3.6.
     # django-otp 0.7 adds support for Django 3.0.
-    py{36,37}-django{30,master}-dotp{07,master}
+    py{36,37,38}-django{30,master}-dotp{07,master}
     # Check code style.
     flake8
 skip_missing_interpreters = True


### PR DESCRIPTION
#86 missed a couple of references and failed to actually run tests on Python 3.8.