### PR TITLE
Remove use of deprecated function.

### DIFF
--- a/allauth_2fa/forms.py
+++ b/allauth_2fa/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from django_otp.forms import OTPAuthenticationFormMixin
 from django_otp.plugins.otp_totp.models import TOTPDevice


### PR DESCRIPTION
`django.utils.translation.ugettext_lazy()` is deprecated in favor of` django.utils.translation.gettext_lazy()` and will be removed in Django 4.0