### PR TITLE
Hint numeric input mode

### DIFF
--- a/allauth_2fa/forms.py
+++ b/allauth_2fa/forms.py
@@ -15,6 +15,7 @@ class TOTPAuthenticateForm(OTPAuthenticationFormMixin, forms.Form):
         self.fields['otp_token'].widget.attrs.update({
             'autofocus': 'autofocus',
             'autocomplete': 'off',
+            'inputmode': 'numeric',
         })
         self.user = user
 


### PR DESCRIPTION
We want to use `inputmode=numeric` instead of `type=number` as leading zeros might be a problem in the latter.

This is mostly a problem on mobile devices.