### PR TITLE
Redirect to next, when given via GET or POST

### DIFF
--- a/allauth_2fa/adapter.py
+++ b/allauth_2fa/adapter.py
@@ -26,9 +26,11 @@ class OTPAdapter(DefaultAccountAdapter):
             view = request.resolver_match.func.view_class()
             view.request = request
             success_url = view.get_success_url()
+            query_params = request.GET.copy()
             if success_url:
-                next_dict = {view.redirect_field_name: success_url}
-                redirect_url += u'?' + urlencode(next_dict)
+                query_params[view.redirect_field_name] = success_url
+            if query_params:
+                redirect_url += u'?' + urlencode(query_params)
 
             raise ImmediateHttpResponse(
                 response=HttpResponseRedirect(redirect_url)

--- a/allauth_2fa/adapter.py
+++ b/allauth_2fa/adapter.py
@@ -22,9 +22,13 @@ class OTPAdapter(DefaultAccountAdapter):
             request.session['allauth_2fa_user_id'] = str(user.id)
 
             redirect_url = reverse('two-factor-authenticate')
-            # Add GET parameters to the URL if they exist.
-            if request.GET:
-                redirect_url += u'?' + urlencode(request.GET)
+            # Add "next" parameter to the URL.
+            view = request.resolver_match.func.view_class()
+            view.request = request
+            success_url = view.get_success_url()
+            if success_url:
+                next_dict = {view.redirect_field_name: success_url}
+                redirect_url += u'?' + urlencode(next_dict)
 
             raise ImmediateHttpResponse(
                 response=HttpResponseRedirect(redirect_url)

--- a/allauth_2fa/adapter.py
+++ b/allauth_2fa/adapter.py
@@ -30,7 +30,7 @@ class OTPAdapter(DefaultAccountAdapter):
             if success_url:
                 query_params[view.redirect_field_name] = success_url
             if query_params:
-                redirect_url += u'?' + urlencode(query_params)
+                redirect_url += '?' + urlencode(query_params)
 
             raise ImmediateHttpResponse(
                 response=HttpResponseRedirect(redirect_url)

--- a/tests/test_allauth_2fa.py
+++ b/tests/test_allauth_2fa.py
@@ -149,14 +149,14 @@ class Test2Factor(TestCase):
         user.totpdevice_set.create()
 
         # Add a next to unnamed-view.
-        resp = self.client.post(reverse('account_login') + '?next=unnamed-view',
+        resp = self.client.post(reverse('account_login') + '?existing=param&next=unnamed-view',
                                 {'login': 'john',
                                  'password': 'doe'}, follow=True)
 
         # Ensure that the unnamed-view is still being forwarded to.
         self.assertRedirects(
             resp,
-            reverse('two-factor-authenticate') + '?next=unnamed-view',
+            reverse('two-factor-authenticate') + '?existing=param&next=unnamed-view',
             fetch_redirect_response=False)
 
     def test_2fa_login_forwarding_next_via_post(self):
@@ -170,15 +170,15 @@ class Test2Factor(TestCase):
         user.totpdevice_set.create()
 
         # Add a next to unnamed-view.
-        resp = self.client.post(reverse('account_login'),
+        resp = self.client.post(reverse('account_login') + '?existing=param',
                                 {'login': 'john',
                                  'password': 'doe',
                                  'next': 'unnamed-view'}, follow=True)
 
-        # Ensure that the unnamed-view is still being forwarded to.
+        # Ensure that the unnamed-view is still being forwarded to, preserving existing query params.
         self.assertRedirects(
             resp,
-            reverse('two-factor-authenticate') + '?next=unnamed-view',
+            reverse('two-factor-authenticate') + '?existing=param&next=unnamed-view',
             fetch_redirect_response=False)
 
     def test_anonymous(self):

--- a/tests/test_allauth_2fa.py
+++ b/tests/test_allauth_2fa.py
@@ -159,6 +159,28 @@ class Test2Factor(TestCase):
             reverse('two-factor-authenticate') + '?next=unnamed-view',
             fetch_redirect_response=False)
 
+    def test_2fa_login_forwarding_next_via_post(self):
+        """
+        Test that the 2FA workflow passes forward to next via POST parameters sent to the
+        TwoFactorAuthenticate view.
+        """
+        user = get_user_model().objects.create(username='john')
+        user.set_password('doe')
+        user.save()
+        user.totpdevice_set.create()
+
+        # Add a next to unnamed-view.
+        resp = self.client.post(reverse('account_login'),
+                                {'login': 'john',
+                                 'password': 'doe',
+                                 'next': 'unnamed-view'}, follow=True)
+
+        # Ensure that the unnamed-view is still being forwarded to.
+        self.assertRedirects(
+            resp,
+            reverse('two-factor-authenticate') + '?next=unnamed-view',
+            fetch_redirect_response=False)
+
     def test_anonymous(self):
         """
         Views should not be hittable via an AnonymousUser.


### PR DESCRIPTION
Fixes https://github.com/percipient/django-allauth-2fa/issues/51