### PR TITLE
Fix adapter login

### DIFF
--- a/allauth_2fa/adapter.py
+++ b/allauth_2fa/adapter.py
@@ -31,4 +31,7 @@ class OTPAdapter(DefaultAccountAdapter):
             )
 
         # Otherwise defer to the original allauth adapter.
+        self.login_without_otp(request, user)
+
+    def login_without_otp(self, request, user):
         return super(OTPAdapter, self).login(request, user)

--- a/allauth_2fa/views.py
+++ b/allauth_2fa/views.py
@@ -55,7 +55,7 @@ class TwoFactorAuthenticate(FormView):
 
         # Skip over the (already done) 2fa login flow and continue the original
         # allauth login flow.
-        super(adapter.__class__, adapter).login(self.request, form.user)
+        adapter.login_without_otp(self.request, form.user)
 
         # Perform the rest of allauth.account.utils.perform_login, this is
         # copied from commit cedad9f156a8c78bfbe43a0b3a723c1a0b840dbd.


### PR DESCRIPTION
`views.py` assumed that the adapter would always be `OTPAdapter`, and calls `login()` on its parent to get `DefaultAccountAdapter.login()`.

This fails when the adapter is subclassed from `OTPAdapter` (for other reasons, in my case that I needed to override a method unrelated to 2FA), because `OTPAdapter.login()` gets called by `TwoFactorAuthenticate.form_valid()`, generating an inadvertent and uncaught `ImmediateHttpResponse`.

The solution is to add a method to `OTPAdapter` that calls `DefaultAccountAdapter.login()` and have `TwoFactorAuthenticate.form_valid()` call it.