### PR TITLE
Require2FAMiddleware improvements

### DIFF
--- a/allauth_2fa/middleware.py
+++ b/allauth_2fa/middleware.py
@@ -1,12 +1,8 @@
-import warnings
-
 from allauth.account.adapter import get_adapter
 from django.conf import settings
 from django.contrib import messages
 from django.shortcuts import redirect
-from django.urls import NoReverseMatch
 from django.urls import resolve
-from django.urls import reverse
 from django.utils.deprecation import MiddlewareMixin
 
 
@@ -90,16 +86,7 @@ class BaseRequire2FAMiddleware(MiddlewareMixin):
         raise NotImplementedError("You must implement require_2fa.")
 
     def is_allowed_page(self, request):
-        for urlname in self.allowed_pages:
-            try:
-                if request.path == reverse(urlname):
-                    return True
-            except NoReverseMatch:
-                # The developer may have misconfigured the list of allowed pages.
-                # Let's not outright crash at that point, but inform the developer about their mishap.
-                warnings.warn(
-                    f"NoReverseMatch for {urlname} while checking for pages allowed without 2FA"
-                )
+        return request.resolver_match.url_name in self.allowed_pages
 
     def process_view(self, request, view_func, view_args, view_kwargs):
         # The user is not logged in, do nothing.


### PR DESCRIPTION
* Refactor BaseRequire2FAMiddleware.is_allowed_page() for subclassability
* Simplify `is_allowed_page` to use ResolverMatch
  * This makes it possible to allow views that would require args/kwargs that can't otherwise be `reverse`d.