### PR TITLE
Show secret on setup.html to allow for manual entry for multiple yubikeys & other devices

### DIFF
--- a/allauth_2fa/templates/allauth_2fa/setup.html
+++ b/allauth_2fa/templates/allauth_2fa/setup.html
@@ -16,6 +16,8 @@
 
 <img src="{{ qr_code_url }}" />
 
+<p> Secret: {{ secret }} </p>
+
 <h4>
   {% trans 'Step 2' %}:
 </h4>

--- a/allauth_2fa/utils.py
+++ b/allauth_2fa/utils.py
@@ -8,9 +8,13 @@ from django.contrib.sites.shortcuts import get_current_site
 from qrcode.image.svg import SvgPathImage
 
 
+def get_device_base32_secret(device):
+    return b32encode(device.bin_key).decode("utf-8")
+
+
 def generate_totp_config_svg(device, issuer, label):
     params = {
-        "secret": b32encode(device.bin_key).decode("utf-8"),
+        "secret": get_device_base32_secret(device),
         "algorithm": "SHA1",
         "digits": device.digits,
         "period": device.step,

--- a/allauth_2fa/views.py
+++ b/allauth_2fa/views.py
@@ -23,6 +23,7 @@ from allauth_2fa.forms import TOTPDeviceForm
 from allauth_2fa.forms import TOTPDeviceRemoveForm
 from allauth_2fa.mixins import ValidTOTPDeviceRequiredMixin
 from allauth_2fa.utils import generate_totp_config_svg_for_device
+from allauth_2fa.utils import get_device_base32_secret
 from allauth_2fa.utils import user_has_valid_totp_device
 
 
@@ -118,6 +119,7 @@ class TwoFactorSetup(LoginRequiredMixin, FormView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["qr_code_url"] = self.get_qr_code_data_uri()
+        context["secret"] = get_device_base32_secret(self.device)
         return context
 
     def get_form_kwargs(self):


### PR DESCRIPTION
This PR allows for users to manually enter the same secret key for multiple mobile devices or multiple yubikey devices using the downloadable yubikey authenticator app in case the user loses one of their yubikeys or mobile devices. In other words, it allows a user to create multiple yubikey or mobile 2FA devices to use for their one online account. By creating backup yubikeys or mobile devices with the same OTP secret on them, it decreases the chances of a user not being able to log into their account if they lose one or more of their yubikey or mobile devices. 