### PR TITLE
Fix for subclassed OTP adapter

### DIFF
--- a/allauth_2fa/views.py
+++ b/allauth_2fa/views.py
@@ -17,6 +17,7 @@ from django_otp.plugins.otp_static.models import StaticToken
 from django_otp.plugins.otp_totp.models import TOTPDevice
 
 from allauth_2fa import app_settings
+from allauth_2fa.adapter import OTPAdapter
 from allauth_2fa.forms import TOTPAuthenticateForm
 from allauth_2fa.forms import TOTPDeviceForm
 from allauth_2fa.forms import TOTPDeviceRemoveForm
@@ -56,7 +57,7 @@ class TwoFactorAuthenticate(FormView):
 
         # Skip over the (already done) 2fa login flow and continue the original
         # allauth login flow.
-        super(adapter.__class__, adapter).login(self.request, form.user)
+        super(OTPAdapter, adapter).login(self.request, form.user)
 
         # Perform the rest of allauth.account.utils.perform_login, this is
         # copied from commit cedad9f156a8c78bfbe43a0b3a723c1a0b840dbd.

--- a/tests/adapter.py
+++ b/tests/adapter.py
@@ -1,0 +1,5 @@
+from allauth_2fa.adapter import OTPAdapter
+
+
+class CustomAdapter(OTPAdapter):
+    pass

--- a/tests/test_allauth_2fa.py
+++ b/tests/test_allauth_2fa.py
@@ -17,6 +17,10 @@ from pytest_django.asserts import assertRedirects
 
 from allauth_2fa.middleware import BaseRequire2FAMiddleware
 
+ADAPTER_CLASSES = [
+    "allauth_2fa.adapter.OTPAdapter",
+    "tests.adapter.CustomAdapter",
+]
 
 TWO_FACTOR_AUTH_URL = reverse_lazy("two-factor-authenticate")
 TWO_FACTOR_SETUP_URL = reverse_lazy("two-factor-setup")
@@ -27,6 +31,18 @@ JOHN_CREDENTIALS = {"login": "john", "password": "doe"}
 @pytest.fixture(autouse=True)
 def enable_db_access_for_all_tests(db):
     pass
+
+
+def pytest_generate_tests(metafunc):
+    if "adapter" in metafunc.fixturenames:
+        metafunc.parametrize("adapter", ADAPTER_CLASSES, indirect=True)
+
+
+@pytest.fixture(autouse=True)
+def adapter(request, settings):
+    settings.ACCOUNT_ADAPTER = request.param
+    # Can be used to verify the class is correct:
+    # assert get_adapter().__class__.__name__ == request.param.rpartition(".")[-1]
 
 
 @pytest.fixture()


### PR DESCRIPTION
When overriding in the `OTPAdapter` class by a custom class, method `form_valid` calls the `login` method on the overriding class instead on the `OTPAdapter`, which breaks the second step after successful OTP validation.

This might be related to #125 and potentially solve this issue as well.

A testcase verifies the common success case; manuall running all tests with the overridden `ACCOUNT_ADAPTER` in `settings.py` shows the validity for all test cases as well.
