### PR TITLE
Require user token to disable 2FA

### DIFF
--- a/allauth_2fa/forms.py
+++ b/allauth_2fa/forms.py
@@ -6,6 +6,12 @@ from django.utils.translation import gettext_lazy as _
 from django_otp.forms import OTPAuthenticationFormMixin
 from django_otp.plugins.otp_totp.models import TOTPDevice
 
+DEFAULT_TOKEN_WIDGET_ATTRS = {
+    "autofocus": "autofocus",
+    "autocomplete": "off",
+    "inputmode": "numeric",
+}
+
 
 class TOTPAuthenticateForm(OTPAuthenticationFormMixin, forms.Form):
     otp_token = forms.CharField(
@@ -14,13 +20,7 @@ class TOTPAuthenticateForm(OTPAuthenticationFormMixin, forms.Form):
 
     def __init__(self, user, **kwargs):
         super().__init__(**kwargs)
-        self.fields["otp_token"].widget.attrs.update(
-            {
-                "autofocus": "autofocus",
-                "autocomplete": "off",
-                "inputmode": "numeric",
-            }
-        )
+        self.fields["otp_token"].widget.attrs.update(DEFAULT_TOKEN_WIDGET_ATTRS)
         self.user = user
 
     def clean(self):
@@ -35,12 +35,7 @@ class TOTPDeviceForm(forms.Form):
 
     def __init__(self, user, metadata=None, **kwargs):
         super().__init__(**kwargs)
-        self.fields["token"].widget.attrs.update(
-            {
-                "autofocus": "autofocus",
-                "autocomplete": "off",
-            }
-        )
+        self.fields["token"].widget.attrs.update(DEFAULT_TOKEN_WIDGET_ATTRS)
         self.user = user
         self.metadata = metadata or {}
 
@@ -74,12 +69,7 @@ class TOTPDeviceRemoveForm(forms.Form):
     def __init__(self, user, **kwargs):
         super().__init__(**kwargs)
         self.user = user
-        self.fields["token"].widget.attrs.update(
-            {
-                "autofocus": "autofocus",
-                "autocomplete": "off",
-            }
-        )
+        self.fields["token"].widget.attrs.update(DEFAULT_TOKEN_WIDGET_ATTRS)
 
     def clean_token(self):
         # Ensure that the user has provided a valid token

--- a/allauth_2fa/templates/allauth_2fa/remove.html
+++ b/allauth_2fa/templates/allauth_2fa/remove.html
@@ -6,10 +6,11 @@
   {% trans "Disable Two-Factor Authentication" %}
 </h1>
 
-<p>{% trans "Are you sure?" %}</p>
+<p>{% trans "Please enter a valid authentication token to disable two-factor authentication:" %}</p>
 
 <form method="post">
   {% csrf_token %}
+  {{ form.as_p }}
   <button type="submit">
     {% trans 'Disable Two-Factor' %}
   </button>

--- a/tests/test_allauth_2fa.py
+++ b/tests/test_allauth_2fa.py
@@ -196,8 +196,12 @@ def test_2fa_removal(client, john_with_totp):
     # Navigate to 2FA removal view
     client.get(reverse("two-factor-remove"))
 
+    # reset throttling and get another token
+    totp_device.throttle_reset()
+    token = get_token_from_totp_device(totp_device)
+
     # ... and POST to confirm
-    client.post(reverse("two-factor-remove"))
+    client.post(reverse("two-factor-remove"), {"token": token})
 
     assert not user.totpdevice_set.exists()
 


### PR DESCRIPTION
Hey @valberg I ran into an issue using your library, which we use over at [InvenTree](https://github.com/inventree/inventree) which has already been reported in #30 

I propose a reasonably simple fix, hopefully it can be merged in soon? 

- Add 'token' field to TOTPDeviceRemoveForm
- Ensure that the user provides a valid token to disable / remove 2FA
- Ref: https://cheatsheetseries.owasp.org/cheatsheets/Multifactor_Authentication_Cheat_Sheet.html

Closes https://github.com/valohai/django-allauth-2fa/issues/30

Please LMK if you require any changes or have any suggestions.