### PR TITLE
Drop support for django-otp 0.5.x

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     django>=2.2
     qrcode>=5.3
     django-allauth>=0.41.0
-    django-otp>=0.5.0
+    django-otp>=0.6.0
 include_package_data = true
 
 [options.packages.find]

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,8 @@
 [tox]
 isolated_build = True
 envlist =
-    # django-otp 0.5 adds support for Django 2.1
-    py{36,37,38,39}-django22-dotp{05,06,07}-allauth41,
+    # django-otp 0.5 adds support for Django 2.1 (but we only support 0.6+)
+    py{36,37,38,39}-django22-dotp{06,07}-allauth41,
 
     # Django 3.0 requires Python 3.6.
     # django-otp 0.7 adds support for Django 3.0.
@@ -43,7 +43,6 @@ deps =
     django31: Django>=3.1,<3.2
     django32: Django>=3.2,<4.0
     django40: Django>=4.0,<4.1
-    dotp05: django-otp>=0.5,<0.6
     dotp06: django-otp>=0.6,<0.7
     dotp07: django-otp>=0.7,<0.8
     dotp08: django-otp>=0.8,<0.9


### PR DESCRIPTION
This version causes confounding CI errors in #135 (see e.g. https://github.com/valohai/django-allauth-2fa/actions/runs/2609225923), and I see no reason to support a version from early 2019. (We're still supporting a version from late 2019...)

