### PR TITLE
Clean up URLs

### DIFF
--- a/allauth_2fa/urls.py
+++ b/allauth_2fa/urls.py
@@ -1,25 +1,25 @@
-from django.urls import re_path
+from django.urls import path
 
 from allauth_2fa import views
 
 urlpatterns = [
-    re_path(
-        r"^two-factor-authenticate/?$",
+    path(
+        "authenticate/",
         views.TwoFactorAuthenticate.as_view(),
         name="two-factor-authenticate",
     ),
-    re_path(
-        r"^two_factor/setup/?$",
+    path(
+        "setup/",
         views.TwoFactorSetup.as_view(),
         name="two-factor-setup",
     ),
-    re_path(
-        r"^two_factor/backup_tokens/?$",
+    path(
+        "backup-tokens/",
         views.TwoFactorBackupTokens.as_view(),
         name="two-factor-backup-tokens",
     ),
-    re_path(
-        r"^two_factor/remove/?$",
+    path(
+        "remove/",
         views.TwoFactorRemove.as_view(),
         name="two-factor-remove",
     ),

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -78,7 +78,7 @@ Finally, you must include the django-allauth-2fa URLs:
 
     urlpatterns = [
         # Include the allauth and 2FA urls from their respective packages.
-        path('accounts/', include('allauth_2fa.urls')),
+        path('accounts/two-factor/', include('allauth_2fa.urls')),
         path('accounts/', include('allauth.urls')),
     ]
 

--- a/tests/test_allauth_2fa.py
+++ b/tests/test_allauth_2fa.py
@@ -266,23 +266,6 @@ def test_anonymous(client):
         )
 
 
-def test_backwards_compatible_url(client, john_with_totp, user_logged_in_count):
-    """Ensure that the old 2FA URLs still work."""
-    # TODO(1.0): remove this test
-    user, totp_device = john_with_totp
-    login(client, expected_redirect_url=TWO_FACTOR_AUTH_URL)
-    # The old URL doesn't have a trailing slash.
-    do_totp_authentication(
-        client,
-        totp_device=totp_device,
-        auth_url=str(TWO_FACTOR_AUTH_URL).rstrip("/"),
-        expected_redirect_url=settings.LOGIN_REDIRECT_URL,
-    )
-
-    # Ensure the signal is received as expected.
-    assert user_logged_in_count() == 1
-
-
 def test_not_configured_redirect(client, john):
     """Viewing backup codes or disabling 2FA should redirect if 2FA is not
     configured."""

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -15,7 +15,7 @@ def login_required_view(request):
 
 urlpatterns = [
     # Include the allauth and 2FA urls from their respective packages.
-    path("accounts/", include("allauth_2fa.urls")),
+    path("accounts/2fa/", include("allauth_2fa.urls")),
     path("accounts/", include("allauth.urls")),
     # A view without a name.
     path("unnamed-view", blank_view),


### PR DESCRIPTION
* URLs require the trailing slash, as is the Django (and allauth) way
* URLs no longer have a hard-coded "two-factor/" prefix; like with allauth, the prefix is left for the `include()`r to decide
* URLs have dashes instead of underscores (like allauth)

Fixes #29