### PR TITLE
Drop support for django-otp 1.0.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ classifiers = [
 
 dependencies = [
     "django-allauth>=0.41.0",
-    "django-otp>=1.0.0",
+    "django-otp>=1.1.0",
     "django>=3.2",
     "qrcode>=5.3",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -7,10 +7,10 @@
 isolated_build = True
 envlist =
     # Django 3.2.9 adds support for Python 3.10
-    py{37,38,39,310}-django{32}-dotp{10,11}-allauth41
+    py{37,38,39,310}-django{32}-dotp{11}-allauth41
 
     # Django 4.0 requires Python 3.8
-    py{38,39,310}-django{40}-dotp{10,11}-allauth41
+    py{38,39,310}-django{40}-dotp{11}-allauth41
 skip_missing_interpreters = True
 requires =
     pip>=20.0
@@ -29,6 +29,5 @@ deps =
     -r requirements-test.txt
     django32: Django>=3.2,<4.0
     django40: Django>=4.0,<4.1
-    dotp10: django-otp>=1.0,<1.1
     dotp11: django-otp>=1.1,<1.2
     allauth41: django-allauth>=0.41.0


### PR DESCRIPTION
We'll be bumping minimum dep versions with #131 anyway, so let's tighten this too.