### PR TITLE
Disabling 2FA should also work with backup tokens.

### DIFF
--- a/allauth_2fa/forms.py
+++ b/allauth_2fa/forms.py
@@ -59,7 +59,7 @@ class TOTPDeviceForm(_TokenToOTPTokenMixin, forms.Form):
         self.user = user
         self.metadata = metadata or {}
 
-    def clean_token(self):
+    def clean_otp_token(self):
         token = self.cleaned_data.get("otp_token")
 
         # Find the unconfirmed device and attempt to verify the token.

--- a/allauth_2fa/forms.py
+++ b/allauth_2fa/forms.py
@@ -17,19 +17,18 @@ DEFAULT_TOKEN_WIDGET_ATTRS = {
 
 
 class _TokenToOTPTokenMixin:
-    exception = ImproperlyConfigured(
-        "The field `token` in TOTPDeviceRemoveForm has been renamed " "to `otp_token`.",
-    )
-
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
         if "token" in self.fields or "token" in self.data:
-            raise self.exception
+            self._raise_token_exception()
 
     @property
     def token(self):
-        raise self.exception
+        self._raise_token_exception()
+        
+    def _raise_token_exception(self):
+        raise ImproperlyConfigured(f"The field `token` in {self} has been renamed to `otp_token`.")
 
 
 class TOTPAuthenticateForm(OTPAuthenticationFormMixin, forms.Form):

--- a/allauth_2fa/forms.py
+++ b/allauth_2fa/forms.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import contextlib
 
 from django import forms
-from django.core.exceptions import ImproperlyConfigured
-from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
 from django.utils.translation import gettext_lazy as _
 from django_otp.forms import OTPAuthenticationFormMixin
 from django_otp.plugins.otp_totp.models import TOTPDevice

--- a/allauth_2fa/forms.py
+++ b/allauth_2fa/forms.py
@@ -26,9 +26,11 @@ class _TokenToOTPTokenMixin:
     @property
     def token(self):
         self._raise_token_exception()
-        
+
     def _raise_token_exception(self):
-        raise ImproperlyConfigured(f"The field `token` in {self} has been renamed to `otp_token`.")
+        raise ImproperlyConfigured(
+            f"The field `token` in {self} has been renamed to `otp_token`.",
+        )
 
 
 class TOTPAuthenticateForm(OTPAuthenticationFormMixin, forms.Form):
@@ -91,7 +93,7 @@ class TOTPDeviceRemoveForm(
         super().__init__(**kwargs)
 
         if "token" in self.fields or "token" in self.data:
-            self. _raise_token_exception()
+            self._raise_token_exception()
 
         self.user = user
         self.fields["otp_token"].widget.attrs.update(DEFAULT_TOKEN_WIDGET_ATTRS)

--- a/allauth_2fa/forms.py
+++ b/allauth_2fa/forms.py
@@ -91,9 +91,6 @@ class TOTPDeviceRemoveForm(
     def __init__(self, user, **kwargs):
         super().__init__(**kwargs)
 
-        if "token" in self.fields or "token" in self.data:
-            self._raise_token_exception()
-
         self.user = user
         self.fields["otp_token"].widget.attrs.update(DEFAULT_TOKEN_WIDGET_ATTRS)
 

--- a/allauth_2fa/forms.py
+++ b/allauth_2fa/forms.py
@@ -91,10 +91,7 @@ class TOTPDeviceRemoveForm(
         super().__init__(**kwargs)
 
         if "token" in self.fields or "token" in self.data:
-            raise ImproperlyConfigured(
-                "The field `token` in TOTPDeviceRemoveForm has been renamed "
-                "to `otp_token`.",
-            )
+            self. _raise_token_exception()
 
         self.user = user
         self.fields["otp_token"].widget.attrs.update(DEFAULT_TOKEN_WIDGET_ATTRS)

--- a/allauth_2fa/forms.py
+++ b/allauth_2fa/forms.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 
 from django import forms
+from django.core.exceptions import ImproperlyConfigured
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils.translation import gettext_lazy as _
 from django_otp.forms import OTPAuthenticationFormMixin
@@ -69,6 +70,15 @@ class TOTPDeviceRemoveForm(OTPAuthenticationFormMixin, forms.Form):
 
     def __init__(self, user, **kwargs):
         super().__init__(**kwargs)
+
+        if self.fields.get("token") or (
+            kwargs.get("data") and "token" in kwargs.get("data")
+        ):
+            raise ImproperlyConfigured(
+                "The field `token` in TOTPDeviceRemoveForm has been renamed "
+                "to `otp_token`.",
+            )
+
         self.user = user
         self.fields["otp_token"].widget.attrs.update(DEFAULT_TOKEN_WIDGET_ATTRS)
 

--- a/allauth_2fa/forms.py
+++ b/allauth_2fa/forms.py
@@ -94,3 +94,10 @@ class TOTPDeviceRemoveForm(OTPAuthenticationFormMixin, forms.Form):
         # Delete TOTP device.
         device = TOTPDevice.objects.get(user=self.user)
         device.delete()
+
+    @property
+    def token(self):
+        raise ImproperlyConfigured(
+            "The field `token` in TOTPDeviceRemoveForm has been renamed "
+            "to `otp_token`.",
+        )

--- a/allauth_2fa/forms.py
+++ b/allauth_2fa/forms.py
@@ -71,9 +71,7 @@ class TOTPDeviceRemoveForm(OTPAuthenticationFormMixin, forms.Form):
     def __init__(self, user, **kwargs):
         super().__init__(**kwargs)
 
-        if self.fields.get("token") or (
-            kwargs.get("data") and "token" in kwargs.get("data")
-        ):
+        if "token" in self.fields or "token" in self.data:
             raise ImproperlyConfigured(
                 "The field `token` in TOTPDeviceRemoveForm has been renamed "
                 "to `otp_token`.",

--- a/allauth_2fa/templates/allauth_2fa/setup.html
+++ b/allauth_2fa/templates/allauth_2fa/setup.html
@@ -29,7 +29,7 @@
 <form method="post">
   {% csrf_token %}
   {{ form.non_field_errors }}
-  {{ form.token.label }}: {{ form.token }}
+  {{ form.otp_token.label }}: {{ form.otp_token }}
 
   <button type="submit">
     {% trans 'Verify' %}

--- a/tests/test_allauth_2fa.py
+++ b/tests/test_allauth_2fa.py
@@ -12,6 +12,7 @@ from django.test import override_settings
 from django.urls import reverse
 from django.urls import reverse_lazy
 from django_otp.oath import TOTP
+from django_otp.plugins.otp_static.models import StaticDevice
 from django_otp.plugins.otp_static.models import StaticToken
 from django_otp.plugins.otp_totp.models import TOTPDevice
 from pytest_django.asserts import assertRedirects

--- a/tests/test_allauth_2fa.py
+++ b/tests/test_allauth_2fa.py
@@ -55,7 +55,7 @@ def john() -> "AbstractUser":
 
 
 @pytest.fixture()
-def john_with_totp(john: AbstractUser) -> Tuple[AbstractUser, TOTPDevice]:
+def john_with_totp(john: AbstractUser) -> Tuple[AbstractUser, TOTPDevice, StaticDevice]:
     totp_model = john.totpdevice_set.create()
     static_model = john.staticdevice_set.create()
     static_model.token_set.create(token=StaticToken.random_token())


### PR DESCRIPTION
Fixes #152 

Since this uses the `OTPAuthenticationFormMixin` the form field name has been changed from `token` to `otp_token` - which is backwards incompatible. Maybe we could do something to mitigate this?