### PR TITLE
Become 0.11.0rc0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*'
   pull_request:
     branches:
       - main
@@ -61,3 +63,24 @@ jobs:
         with:
           name: dist
           path: dist/
+  Publish:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    needs:
+      - Build
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+      url: https://pypi.org/p/django-allauth-2fa/
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: dist
+          path: dist/
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true
+          print-hash: true

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,39 @@
 Changelog
 #########
 
+0.11.0 - July 4, 2023
+=====================
+
+We didn't wait one year from the last release for this on purpose, I swear!
+
+Minimum dependency versions
+---------------------------
+
+* The minimum version of Python for this release is 3.7.
+* The minimum version of Django for this release is 3.2.
+* The minimum version of django-otp for this release is 1.1.x.
+* The minimum version of django-allauth for this release is 0.53.0.
+
+Possibly breaking changes
+-------------------------
+
+* The `token` field in forms is now `otp_token`; if you have subclassed forms,
+  or are using custom templates, this may require adjustment.
+
+New features
+------------
+
+* Allow customizing view success URLs via app_settings
+* Show secret on setup page to allow for non-QR-code devices
+* You can customize the QR code generation arguments in TwoFactorSetup (#156)
+* 2FA can be disabled using backup tokens (#155)
+* You can now override the forms used by the views using settings, like allauth does (#161)
+
+Infrastructure
+--------------
+
+* The package now has (partial) type annotations.
+
 0.10.0 - July 4, 2022
 =====================
 

--- a/allauth_2fa/__init__.py
+++ b/allauth_2fa/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.10.0"
+__version__ = "0.11.0rc0"


### PR DESCRIPTION
<del>(rc0 only to test that the publish workflow works)</del>

Results of fancy publish workflow: 
* https://github.com/valohai/django-allauth-2fa/actions/runs/5454939302/jobs/9925720526#logs
* https://pypi.org/project/django-allauth-2fa/0.11.0rc0/