### PR TITLE
Add flag and logic to removal form to make otp for device removal optional

### DIFF
--- a/allauth_2fa/app_settings.py
+++ b/allauth_2fa/app_settings.py
@@ -30,5 +30,5 @@ FORMS = getattr(settings, "ALLAUTH_2FA_FORMS", {})
 REQUIRE_OTP_ON_DEVICE_REMOVAL = getattr(
     settings,
     "ALLAUTH_2FA_REQUIRE_OTP_ON_DEVICE_REMOVAL",
-    True
+    True,
 )

--- a/allauth_2fa/app_settings.py
+++ b/allauth_2fa/app_settings.py
@@ -26,3 +26,9 @@ SETUP_SUCCESS_URL = getattr(
 )
 
 FORMS = getattr(settings, "ALLAUTH_2FA_FORMS", {})
+
+REQUIRE_OTP_ON_DEVICE_REMOVAL = getattr(
+    settings,
+    "ALLAUTH_2FA_REQUIRE_OTP_ON_DEVICE_REMOVAL",
+    True
+)

--- a/allauth_2fa/forms.py
+++ b/allauth_2fa/forms.py
@@ -86,9 +86,8 @@ class TOTPDeviceRemoveForm(
     OTPAuthenticationFormMixin,
     forms.Form,
 ):
-
     def __init__(self, user, **kwargs):
-        super(TOTPDeviceRemoveForm, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self.user = user
         # user has to enter OTP token to remove device if REQUIRE_OTP_ON_DEVICE_REMOVAL is True

--- a/allauth_2fa/forms.py
+++ b/allauth_2fa/forms.py
@@ -9,6 +9,8 @@ from django.utils.translation import gettext_lazy as _
 from django_otp.forms import OTPAuthenticationFormMixin
 from django_otp.plugins.otp_totp.models import TOTPDevice
 
+from allauth_2fa import app_settings
+
 DEFAULT_TOKEN_WIDGET_ATTRS = {
     "autofocus": "autofocus",
     "autocomplete": "off",
@@ -84,19 +86,20 @@ class TOTPDeviceRemoveForm(
     OTPAuthenticationFormMixin,
     forms.Form,
 ):
-    # User must input a valid token so 2FA can be removed
-    otp_token = forms.CharField(
-        label=_("Token"),
-    )
 
     def __init__(self, user, **kwargs):
-        super().__init__(**kwargs)
+        super(TOTPDeviceRemoveForm, self).__init__(**kwargs)
 
         self.user = user
-        self.fields["otp_token"].widget.attrs.update(DEFAULT_TOKEN_WIDGET_ATTRS)
+        # user has to enter OTP token to remove device if REQUIRE_OTP_ON_DEVICE_REMOVAL is True
+        if app_settings.REQUIRE_OTP_ON_DEVICE_REMOVAL:
+            self.fields["otp_token"] = forms.CharField(label=_("Token"), required=True)
+            self.fields["otp_token"].widget.attrs.update(DEFAULT_TOKEN_WIDGET_ATTRS)
 
     def clean(self):
-        self.clean_otp(self.user)
+        # clean OTP token if REQUIRE_OTP_ON_DEVICE_REMOVAL is True
+        if app_settings.REQUIRE_OTP_ON_DEVICE_REMOVAL:
+            self.clean_otp(self.user)
         return self.cleaned_data
 
     def save(self) -> None:

--- a/allauth_2fa/forms.py
+++ b/allauth_2fa/forms.py
@@ -90,7 +90,8 @@ class TOTPDeviceRemoveForm(
         super().__init__(**kwargs)
 
         self.user = user
-        # user has to enter OTP token to remove device if REQUIRE_OTP_ON_DEVICE_REMOVAL is True
+        # user has to enter OTP token to remove device
+        # if REQUIRE_OTP_ON_DEVICE_REMOVAL is True
         if app_settings.REQUIRE_OTP_ON_DEVICE_REMOVAL:
             self.fields["otp_token"] = forms.CharField(label=_("Token"), required=True)
             self.fields["otp_token"].widget.attrs.update(DEFAULT_TOKEN_WIDGET_ATTRS)

--- a/allauth_2fa/templates/allauth_2fa/remove.html
+++ b/allauth_2fa/templates/allauth_2fa/remove.html
@@ -6,7 +6,9 @@
   {% trans "Disable Two-Factor Authentication" %}
 </h1>
 
-<p>{% trans "Please enter a valid authentication token to disable two-factor authentication:" %}</p>
+{% if form.otp_token %}
+    <p>{% trans "Please enter a valid authentication token to disable two-factor authentication:" %}</p>
+{% endif %}
 
 <form method="post">
   {% csrf_token %}

--- a/tests/test_allauth_2fa.py
+++ b/tests/test_allauth_2fa.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Callable
 from unittest.mock import Mock
-from unittest.mock import patch
 
 import pytest
 from allauth.account.signals import user_logged_in
@@ -221,9 +220,11 @@ def test_2fa_reset_flow(client, john_with_totp, target_url):
 
 
 @pytest.mark.parametrize("token_state", ["none", "correct", "static", "incorrect"])
-@patch.object(app_settings, "REQUIRE_OTP_ON_DEVICE_REMOVAL", new=True)
-def test_2fa_removal(client, john_with_totp, token_state):
-    """Removing 2FA should be possible with a correct token."""
+@pytest.mark.parametrize("require_token", [False, True])
+def test_2fa_removal(client, john_with_totp, token_state, require_token, monkeypatch):
+    monkeypatch.setattr(app_settings, "REQUIRE_OTP_ON_DEVICE_REMOVAL", require_token)
+    """Removing 2FA should be possible with a correct token
+    or without one if REQUIRE_OTP_ON_DEVICE_REMOVAL is False."""
     user, totp_device, static_device = john_with_totp
     login(client, expected_redirect_url=TWO_FACTOR_AUTH_URL)
     do_totp_authentication(
@@ -236,13 +237,13 @@ def test_2fa_removal(client, john_with_totp, token_state):
     # Navigate to 2FA removal view
     client.get(reverse("two-factor-remove"))
 
-    if token_state == "correct":
+    if token_state == "correct" and require_token:
         # reset throttling and get another token
         totp_device.throttle_reset()
         form_data = {"otp_token": get_token_from_totp_device(totp_device)}
-    elif token_state == "static":
+    elif token_state == "static" and require_token:
         form_data = {"otp_token": static_device.token_set.first().token}
-    elif token_state == "incorrect":
+    elif token_state == "incorrect" and require_token:
         form_data = {"otp_token": "hernekeitto"}
     else:
         form_data = {}
@@ -250,31 +251,12 @@ def test_2fa_removal(client, john_with_totp, token_state):
     # ... and POST to confirm
     client.post(reverse("two-factor-remove"), form_data)
 
-    # The only case when the TOTP device should be removed is when the token is correct.
     was_removed = not user.totpdevice_set.exists()
-    assert was_removed == (token_state == "correct" or token_state == "static")
-
-
-@patch.object(app_settings, "REQUIRE_OTP_ON_DEVICE_REMOVAL", new=False)
-def test_2fa_removal_without_otp(client, john_with_totp):
-    """Removing 2FA should be possible with a correct token."""
-    user, totp_device, static_device = john_with_totp
-    login(client, expected_redirect_url=TWO_FACTOR_AUTH_URL)
-    do_totp_authentication(
-        client,
-        totp_device=totp_device,
-        expected_redirect_url=settings.LOGIN_REDIRECT_URL,
-    )
-    assert user.totpdevice_set.exists()
-
-    # Navigate to 2FA removal view
-    client.get(reverse("two-factor-remove"))
-    # ... and POST to confirm
-    client.post(reverse("two-factor-remove"), {})
-
-    # The only case when the TOTP device should be removed is when the token is correct.
-    was_removed = not user.totpdevice_set.exists()
-    assert was_removed
+    if require_token:
+        # TOTP device should only be removed when the token is correct.
+        assert was_removed == (token_state in ["correct", "static"])
+    else:
+        assert was_removed
 
 
 @pytest.mark.parametrize("next_via", ["get", "post"])

--- a/tests/test_allauth_2fa.py
+++ b/tests/test_allauth_2fa.py
@@ -221,7 +221,7 @@ def test_2fa_reset_flow(client, john_with_totp, target_url):
 
 
 @pytest.mark.parametrize("token_state", ["none", "correct", "static", "incorrect"])
-@patch.object(app_settings, 'REQUIRE_OTP_ON_DEVICE_REMOVAL', new=True)
+@patch.object(app_settings, "REQUIRE_OTP_ON_DEVICE_REMOVAL", new=True)
 def test_2fa_removal(client, john_with_totp, token_state):
     """Removing 2FA should be possible with a correct token."""
     user, totp_device, static_device = john_with_totp
@@ -255,7 +255,7 @@ def test_2fa_removal(client, john_with_totp, token_state):
     assert was_removed == (token_state == "correct" or token_state == "static")
 
 
-@patch.object(app_settings, 'REQUIRE_OTP_ON_DEVICE_REMOVAL', new=False)
+@patch.object(app_settings, "REQUIRE_OTP_ON_DEVICE_REMOVAL", new=False)
 def test_2fa_removal_without_otp(client, john_with_totp):
     """Removing 2FA should be possible with a correct token."""
     user, totp_device, static_device = john_with_totp


### PR DESCRIPTION
I tried to implement the feature specified in #169.
I also wrote a test for the device removal with and without required otp.

Would be nice to get a review on that :)