### PR TITLE
Potential bugfix for AttributeError: 'PasswordResetFromKeyView' object has no attribute 'redirect_field_name'

### DIFF
--- a/allauth_2fa/adapter.py
+++ b/allauth_2fa/adapter.py
@@ -46,8 +46,9 @@ class OTPAdapter(DefaultAccountAdapter):
 
         # Add "next" parameter to the URL if possible.
         # If the view function smells like a class-based view, we can interrogate it.
-        if getattr(request, "resolver_match", None) and \
-            getattr(request.resolver_match.func, "view_class", None):
+        if getattr(request, "resolver_match", None) and getattr(
+            request.resolver_match.func, "view_class", None
+        ):
             view = request.resolver_match.func.view_class()
             view.request = request
             success_url = view.get_success_url()

--- a/allauth_2fa/adapter.py
+++ b/allauth_2fa/adapter.py
@@ -11,7 +11,8 @@ from django.http import HttpResponse
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 
-from allauth_2fa.utils import user_has_valid_totp_device, get_next_query_string
+from allauth_2fa.utils import get_next_query_string
+from allauth_2fa.utils import user_has_valid_totp_device
 
 
 class OTPAdapter(DefaultAccountAdapter):

--- a/allauth_2fa/adapter.py
+++ b/allauth_2fa/adapter.py
@@ -46,7 +46,8 @@ class OTPAdapter(DefaultAccountAdapter):
 
         # Add "next" parameter to the URL if possible.
         # If the view function smells like a class-based view, we can interrogate it.
-        if getattr(request.resolver_match.func, "view_class", None):
+        if getattr(request, "resolver_match", None) and \
+            getattr(request.resolver_match.func, "view_class", None):
             view = request.resolver_match.func.view_class()
             view.request = request
             success_url = view.get_success_url()

--- a/allauth_2fa/adapter.py
+++ b/allauth_2fa/adapter.py
@@ -11,7 +11,7 @@ from django.http import HttpResponse
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 
-from allauth_2fa.utils import user_has_valid_totp_device
+from allauth_2fa.utils import user_has_valid_totp_device, get_next_query_string
 
 
 class OTPAdapter(DefaultAccountAdapter):
@@ -46,11 +46,7 @@ class OTPAdapter(DefaultAccountAdapter):
 
         # Add "next" parameter to the URL if possible.
         # If the view function smells like a class-based view, we can interrogate it.
-        if getattr(request, "resolver_match", None) and getattr(
-            request.resolver_match.func,
-            "view_class",
-            None,
-        ):
+        if get_next_query_string(request):
             view = request.resolver_match.func.view_class()
             view.request = request
             success_url = view.get_success_url()

--- a/allauth_2fa/adapter.py
+++ b/allauth_2fa/adapter.py
@@ -51,7 +51,7 @@ class OTPAdapter(DefaultAccountAdapter):
             view.request = request
             success_url = view.get_success_url()
             query_params = request.GET.copy()
-            if success_url:
+            if success_url and hasattr(view, "redirect_field_name"):
                 query_params[view.redirect_field_name] = success_url
             if query_params:
                 redirect_url += f"?{urlencode(query_params)}"

--- a/allauth_2fa/adapter.py
+++ b/allauth_2fa/adapter.py
@@ -47,7 +47,9 @@ class OTPAdapter(DefaultAccountAdapter):
         # Add "next" parameter to the URL if possible.
         # If the view function smells like a class-based view, we can interrogate it.
         if getattr(request, "resolver_match", None) and getattr(
-            request.resolver_match.func, "view_class", None
+            request.resolver_match.func,
+            "view_class",
+            None,
         ):
             view = request.resolver_match.func.view_class()
             view.request = request

--- a/allauth_2fa/utils.py
+++ b/allauth_2fa/utils.py
@@ -8,6 +8,7 @@ from urllib.parse import urlencode
 import qrcode
 from django_otp.models import Device
 from qrcode.image.svg import SvgPathImage
+from django.http import HttpRequest
 
 
 def get_device_base32_secret(device: Device) -> str:
@@ -39,11 +40,13 @@ def user_has_valid_totp_device(user) -> bool:
 
 def get_next_query_string(request: HttpRequest) -> str | None:
     """
-    Get the query string (including the prefix `?`) to redirect to after a successful POST.
+    Get the query string (including the prefix `?`) to
+    redirect to after a successful POST.
     
     If a query string can't be determined, returns None.
     """
-    # If the view function smells like a class-based view, we can interrogate it.
+    # If the view function smells like a class-based view,
+    # we can interrogate it.
     try:
         view = request.resolver_match.func.view_class()
         redirect_field_name = view.redirect_field_name

--- a/allauth_2fa/utils.py
+++ b/allauth_2fa/utils.py
@@ -6,9 +6,9 @@ from urllib.parse import quote
 from urllib.parse import urlencode
 
 import qrcode
+from django.http import HttpRequest
 from django_otp.models import Device
 from qrcode.image.svg import SvgPathImage
-from django.http import HttpRequest
 
 
 def get_device_base32_secret(device: Device) -> str:
@@ -42,7 +42,7 @@ def get_next_query_string(request: HttpRequest) -> str | None:
     """
     Get the query string (including the prefix `?`) to
     redirect to after a successful POST.
-    
+
     If a query string can't be determined, returns None.
     """
     # If the view function smells like a class-based view,

--- a/allauth_2fa/utils.py
+++ b/allauth_2fa/utils.py
@@ -35,3 +35,27 @@ def user_has_valid_totp_device(user) -> bool:
     if not user.is_authenticated:
         return False
     return user.totpdevice_set.filter(confirmed=True).exists()
+
+
+def get_next_query_string(request: HttpRequest) -> str | None:
+    """
+    Get the query string (including the prefix `?`) to redirect to after a successful POST.
+    
+    If a query string can't be determined, returns None.
+    """
+    # If the view function smells like a class-based view, we can interrogate it.
+    try:
+        view = request.resolver_match.func.view_class()
+        redirect_field_name = view.redirect_field_name
+    except AttributeError:
+        # Interrogation failed :(
+        return None
+
+    view.request = request
+    query_params = request.GET.copy()
+    success_url = view.get_success_url()
+    if success_url:
+        query_params[redirect_field_name] = success_url
+    if query_params:
+        return f"?{urlencode(query_params)}"
+    return None

--- a/tests/test_allauth_2fa.py
+++ b/tests/test_allauth_2fa.py
@@ -20,8 +20,8 @@ from django_otp.plugins.otp_static.models import StaticToken
 from django_otp.plugins.otp_totp.models import TOTPDevice
 from pytest_django.asserts import assertRedirects
 
-from allauth_2fa.adapter import OTPAdapter
 from allauth_2fa import views
+from allauth_2fa.adapter import OTPAdapter
 from allauth_2fa.middleware import BaseRequire2FAMiddleware
 
 from . import forms as forms_overrides
@@ -383,7 +383,7 @@ def test_forms_override(
     ("view_cls"),
     [
         (PasswordResetFromKeyView),
-    ]
+    ],
 )
 def test_view_missing_attribute(
     request,
@@ -393,8 +393,8 @@ def test_view_missing_attribute(
 
     # Ensure we're testing a view that's missing the attribute.
     with pytest.raises(AttributeError):
-        getattr(view, "redirect_field_name")
-        
+        view.redirect_field_name
+
     adapter = OTPAdapter()
 
     # Ensure the function doesn't fail when the attribute is missing.

--- a/tests/test_allauth_2fa.py
+++ b/tests/test_allauth_2fa.py
@@ -392,8 +392,7 @@ def test_view_missing_attribute(
     view = view_cls()
 
     # Ensure we're testing a view that's missing the attribute.
-    with pytest.raises(AttributeError):
-        view.redirect_field_name
+    assert hasattr(view, "get_redirect_field_name") is False
 
     adapter = OTPAdapter()
 


### PR DESCRIPTION
Getting this error when submitting the change password form after opening a key-based password reset link.

`AttributeError: 'PasswordResetFromKeyView' object has no attribute 'redirect_field_name'`

I'm using an Adapter that combines the OTPAdapter from this library and InvitationsAdapter from django-invitations, so this issue may or may not be present for others, but the change adds a simple safety check.

Full stack trace:
```
127.0.0.1 - - [17/Jul/2023 11:50:26] "POST /accounts/password/reset/key/1-set-password/ HTTP/1.1" 500 -
Traceback (most recent call last):
  File "\lib\site-packages\django\contrib\staticfiles\handlers.py", line 76, in __call__
    return self.application(environ, start_response)
  File "\lib\site-packages\django\core\handlers\wsgi.py", line 133, in __call__
    response = self.get_response(request)
  File "\lib\site-packages\django\core\handlers\base.py", line 130, in get_response
    response = self._middleware_chain(request)
  File "\lib\site-packages\django\core\handlers\exception.py", line 49, in inner
    response = response_for_exception(request, exc)
  File "\lib\site-packages\django\core\handlers\exception.py", line 114, in response_for_exception
    response = handle_uncaught_exception(request, get_resolver(get_urlconf()), sys.exc_info())
  File "\lib\site-packages\django\core\handlers\exception.py", line 149, in handle_uncaught_exception
    return debug.technical_500_response(request, *exc_info)
  File "\lib\site-packages\django_extensions\management\technical_response.py", line 40, in null_technical_500_response
    raise exc_value.with_traceback(tb)
  File "\lib\site-packages\django\core\handlers\exception.py", line 47, in inner
    response = get_response(request)
  File "\lib\site-packages\django\core\handlers\base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "\lib\site-packages\django\views\generic\base.py", line 70, in view
    return self.dispatch(request, *args, **kwargs)
  File "\lib\site-packages\django\utils\decorators.py", line 43, in _wrapper
    return bound_method(*args, **kwargs)
  File "\lib\site-packages\allauth\decorators.py", line 20, in wrap
    resp = function(request, *args, **kwargs)
  File "\lib\site-packages\allauth\account\views.py", line 763, in dispatch
    return super(PasswordResetFromKeyView, self).dispatch(
  File "\lib\site-packages\django\views\generic\base.py", line 98, in dispatch
    return handler(request, *args, **kwargs)
  File "\lib\site-packages\allauth\account\views.py", line 105, in post
    response = self.form_valid(form)
  File "\lib\site-packages\allauth\account\views.py", line 822, in form_valid
    return perform_login(
  File "\lib\site-packages\allauth\account\utils.py", line 168, in perform_login
    response = adapter.pre_login(request, user, **hook_kwargs)
  File "\src\django-allauth-2fa\allauth_2fa\adapter.py", line 33, in pre_login
    redirect_url = self.get_2fa_authenticate_url(request)
  File "\src\django-allauth-2fa\allauth_2fa\adapter.py", line 53, in get_2fa_authenticate_url
    query_params[view.redirect_field_name] = success_url
AttributeError: 'PasswordResetFromKeyView' object has no attribute 'redirect_field_name'
```