### PR TITLE
Pin allauth due to template changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "django-allauth>=0.53.0",
+    # Pinned to due to backward-incompatible template changes in 0.58.0.
+    "django-allauth>=0.53.0,<0.58.0",
     "django-otp>=1.2.0",
     "django>=4.1",
     "qrcode>=5.3",


### PR DESCRIPTION
https://github.com/pennersr/django-allauth/commit/ff1a6a38e14b0542a23362e650eb8d88e8edd73a moves `account/base.html` elsewhere.